### PR TITLE
Add support for streaming load/save from/to s3

### DIFF
--- a/hnswlib/graft_utils/blockbuf.h
+++ b/hnswlib/graft_utils/blockbuf.h
@@ -1,0 +1,259 @@
+#ifndef GRAFT_BLOCKBUF_H
+#define GRAFT_BLOCKBUF_H
+
+#include <iostream>
+#include <streambuf>
+#include <vector>
+
+// This class provides a c++ stream interface to a block storage device. The
+// underlying abstraction to that device is that blocks can be read/written
+// atomically.
+
+namespace graft {
+
+class blockbuf : public std::streambuf {
+  public:
+    // Typedefs:
+    typedef std::streambuf::char_type char_type;
+    typedef std::streambuf::traits_type traits_type;
+    typedef std::streambuf::int_type int_type;
+    typedef std::streambuf::pos_type pos_type;
+    typedef std::streambuf::off_type off_type;
+   
+    // Constructors:
+    explicit blockbuf(size_t blocksize);
+    ~blockbuf() override = default;
+
+	protected:
+		// Block storage interface
+		// Read block into buffer beginning at offset, return the size of the block, or -1 for error.
+		virtual int read(size_t block_id, char_type* buffer, size_t offset) = 0;
+		// Write buffer to a block, return the size of the block, or -1 for error.
+		virtual int write(size_t block_id, char_type* buffer, size_t n) = 0; 
+
+  private:
+    // Get/Input/Read Area
+    std::vector<char_type> get_area_;
+		int get_id_;
+    // Put/Output/Write Area
+    std::vector<char_type> put_area_;
+		int put_id_;
+		// Buffer
+		// Blocksize
+		size_t blocksize_;
+
+    // Locales: 
+    void imbue(const std::locale& loc) override;
+
+    // Positioning:
+    blockbuf* setbuf(char_type* s, std::streamsize n) override;
+    pos_type seekoff(off_type off, std::ios_base::seekdir dir, std::ios_base::openmode which = std::ios_base::in | std::ios_base::out) override;
+    pos_type seekpos(pos_type pos, std::ios_base::openmode which = std::ios_base::in | std::ios_base::out) override;
+    int sync() override;
+
+    // Get Area:
+    std::streamsize showmanyc() override;
+    int_type underflow() override;
+    int_type uflow() override;
+    std::streamsize xsgetn(char_type* s, std::streamsize count) override;
+
+    // Put Area:
+    std::streamsize xsputn(const char_type* s, std::streamsize count) override;
+    int_type overflow(int_type c = traits_type::eof()) override;
+
+    // Undo:
+    int_type pbackfail(int_type c = traits_type::eof()) override;
+
+		// Put Area Helper Methods:
+		// Push back the end of the put area to make up to blocksize bytes of n available.
+		int extend_put_area(size_t n);
+		// Sync the put area, move to the next block id, and make up to blocksize bytes of n available.
+		int bump_put_area(size_t n);
+};
+
+inline blockbuf::blockbuf(size_t blocksize) : get_area_(blocksize), get_id_(-1), put_area_(blocksize), put_id_(0), blocksize_(blocksize) {
+	// Configure get and put areas to fault on first read/write
+  setg(get_area_.data(), get_area_.data(), get_area_.data());
+  setp(put_area_.data(), put_area_.data()+1);
+}
+
+inline void blockbuf::imbue(const std::locale& loc) {
+  // Default implementation. Does nothing.
+  (void) loc;
+}
+
+inline blockbuf* blockbuf::setbuf(char_type* s, std::streamsize n) {
+  // Default implementation. Does nothing.
+  (void) s;
+  (void) n;
+  return this;
+}
+
+inline blockbuf::pos_type blockbuf::seekoff(off_type off, std::ios_base::seekdir dir, std::ios_base::openmode which) {
+  // Does nothing.
+	// TODO(eschkufz): Update get/put, page in new blocks if necessary.
+  (void) off;
+  (void) dir;
+  (void) which;
+  return pos_type(off_type(-1));
+}
+
+inline blockbuf::pos_type blockbuf::seekpos(pos_type pos, std::ios_base::openmode which) {
+	// Does nothing.
+	// TODO(eschkufz): Update get/put, page in new blocks if necessary.
+  (void) pos;
+  (void) which;
+  return pos_type(off_type(-1));
+}
+
+inline int blockbuf::sync() {
+	// If the put area is empty, there's nothing to do.
+	if (pptr() == pbase()) {
+		return 0;
+	}
+	// If the put area doesn't span a full block, we need to read the part of the block we're missing.
+	const auto offset = pptr()-pbase();
+	auto size = offset;
+	if (size != blocksize_) {
+		size = read(put_id_, put_area_.data(), offset);
+		if (size == -1) {
+			return -1;
+		}
+		size = std::max(size, offset);
+		setp(pbase(), pbase()+size);
+		pbump(offset);
+	}
+	// Write back 
+	if (write(put_id_, put_area_.data(), size) == -1) {
+		return -1;
+	}
+	// If get and put areas refer to the same block, copy the put area to the get area.
+	if (get_id_ == put_id_) {
+		const auto n = epptr()-pbase();
+		std::copy(pbase(), epptr(), eback());
+		setg(eback(), gptr(), eback()+n);
+	}
+	return 0;
+}
+
+inline std::streamsize blockbuf::showmanyc() {
+	// The largest contiguous read we support is whatever is left in the get area.
+  return egptr() - gptr();
+}
+
+inline blockbuf::int_type blockbuf::underflow() {
+	// Read the next block from block storage.
+	const auto n = read(get_id_+1, eback(), 0);
+	// If the read returned zero bytes, we're at the end of file.
+	if (n == 0) {
+    return traits_type::eof(); 
+	}
+	// Otherwise, increment the get pointer and reset the get area.
+	++get_id_;			
+  setg(eback(), eback(), eback()+n);
+	// Return the first element in the new get area.
+  return traits_type::to_int_type(get_area_[0]);
+}
+
+inline blockbuf::int_type blockbuf::uflow() {
+	// Call underflow() to refresh the get area
+	const auto res = underflow();
+	// If underflow didn't return eof, bump the get pointer.
+	if (res != traits_type::eof()) {
+		gbump(1);
+	}
+	// Return the result of the call to underflow().
+	return res;
+}
+
+inline std::streamsize blockbuf::xsgetn(char_type* s, std::streamsize count) {
+  std::streamsize total = 0;
+  while (total < count) {
+		// Compute how much we have left to read
+		const auto remaining = count-total;
+		// Compute what's left in the get area, and underflow if we're out of characters
+		auto available = showmanyc();
+		if ((available == 0) && (underflow() == traits_type::eof())) {
+			break;
+		}
+		available = showmanyc();
+		// Read whichever is smaller, what's available or what's remaining to be read
+    const auto chunk_size = std::min(available, remaining);
+    std::copy(gptr(), gptr()+chunk_size, s+total);
+    total += chunk_size;
+		// Bump the get pointer
+		gbump(chunk_size);
+  } 
+  return total;
+}
+
+inline std::streamsize blockbuf::xsputn(const char_type* s, std::streamsize count) {
+  std::streamsize total = 0;
+  while (total < count) {
+		// Compute how much we have left to write
+		const auto remaining = count-total;
+		// Compute what's left in the put area, and overflow if we're out of characters
+		auto available = epptr()-pptr();
+		if ((available == 0) && (extend_put_area(remaining) == -1) && (bump_put_area(remaining) == -1)) {
+			break;
+		}
+		available = epptr()-pptr();
+		// Write whichever is smaller, what's available or what's remaining to be written
+    const auto chunk_size = std::min(available, count-total);
+    std::copy(s+total, s+total+chunk_size, pptr());
+    total += chunk_size;
+		// Bump the get pointer
+		pbump(chunk_size);
+  } 
+  return total;
+}
+
+inline blockbuf::int_type blockbuf::overflow(int_type c) {
+	// If we can't extend the put area or bump the put area, return eof to signal error
+	if ((extend_put_area(1) == -1) && (bump_put_area(1) == -1)) {
+		return traits_type::eof();
+	}
+	// Nothing else to do for an eof character.
+  if (c == traits_type::eof()) {
+    return traits_type::to_int_type('0');
+  }
+	// Otherwise, write this char to the put area and return success.
+	*pptr() = c;
+  return traits_type::to_int_type(c);
+}
+
+inline blockbuf::int_type blockbuf::pbackfail(int_type c) {
+	// Does nothing.
+	// TODO(eschkufz): Page back to the previous block and keep producing characters
+  return traits_type::eof();
+}
+
+inline int blockbuf::extend_put_area(size_t n) {
+	// We can't do anything if the put area spans an entire block.
+	const auto capacity = blocksize_ - (epptr()-pbase());
+	if (capacity == 0) {
+		return -1;
+	}
+	// Extend by what's left or the request, whichever is smaller.
+	const auto current = pptr()-pbase();
+	const auto extension = std::min(n, capacity);
+	setp(pbase(), pbase()+current+extension);
+	pbump(current);
+	return 0;
+}
+
+inline int blockbuf::bump_put_area(size_t n) {
+	// Sync the put area.
+	if (sync() == -1) {
+		return -1;
+	}
+	// Reset pointers
+	++put_id_;
+	const auto extension = std::min(n, blocksize_);
+	setp(pbase(), pbase()+extension);
+	return 0;
+}
+
+} // namespace graft
+
+#endif

--- a/hnswlib/graft_utils/blockbuf.h
+++ b/hnswlib/graft_utils/blockbuf.h
@@ -109,7 +109,6 @@ inline void blockbuf::open(std::ios_base::openmode mode) {
 	// Append mode: 
 	// Position write head at end of last block, get area to fault on first read.
 	if (mode & std::ios_base::app) {
-		std::cout << "OPEN IN APPEND MODE" << std::endl;
 		put_id_ = device_end() - 1;
 		const auto n = read(put_id_, put_area_, 0);
 		setp(put_area_, put_area_+n);
@@ -184,7 +183,6 @@ inline blockbuf::pos_type blockbuf::seekpos(pos_type pos, std::ios_base::openmod
 	if (which & std::ios_base::in) {
 		int capacity = egptr()-eback();
 		if (block_id != get_id_) {
-			std::cout << "JUMP TO NEW GET AREA" << std::endl;
 			capacity = read(block_id, get_area_, 0);
 			if ((capacity == -1) || (offset > capacity)) {
 				return pos_type(off_type(-1));
@@ -199,7 +197,6 @@ inline blockbuf::pos_type blockbuf::seekpos(pos_type pos, std::ios_base::openmod
 		if (block_id != put_id_) {
 			sync();
 			put_id_ = block_id;
-			std::cout << "JUMP TO NEW PUT AREA" << std::endl;
 			const auto capacity = read(put_id_, put_area_, 0);
 			if ((capacity == -1) || (offset > capacity)) {
 				return pos_type	(off_type(-1));
@@ -210,7 +207,6 @@ inline blockbuf::pos_type blockbuf::seekpos(pos_type pos, std::ios_base::openmod
 		// Jumping past epptr(): Refresh the curent block, and reset pointers.
 		else if (offset >= (epptr()-pbase())) {
 			const auto size = pptr()-pbase();
-			std::cout << "JUMP WITHIN PUT AREA" << std::endl;
 			const auto capacity = read(put_id_, put_area_, size);
 			if ((capacity == -1) || (offset > capacity)) {
 				return pos_type	(off_type(-1));
@@ -228,7 +224,6 @@ inline blockbuf::pos_type blockbuf::seekpos(pos_type pos, std::ios_base::openmod
 }
 
 inline int blockbuf::sync() {
-	std::cout << "SYNC" << std::endl;
 	// If the dirty bit isn't set there's nothing to do.
 	if (!dirty_) {
 		return 0;
@@ -268,7 +263,6 @@ inline std::streamsize blockbuf::showmanyc() {
 }
 
 inline blockbuf::int_type blockbuf::underflow() {
-	std::cout << "UNDERFLOW" << std::endl;
 	// If this is the last block, we're at the end of file
 	if (get_id_+1 == device_end()) {
     return traits_type::eof(); 

--- a/hnswlib/graft_utils/blockbuf.h
+++ b/hnswlib/graft_utils/blockbuf.h
@@ -151,7 +151,11 @@ inline blockbuf::pos_type blockbuf::seekoff(off_type off, std::ios_base::seekdir
 		pos.first = pos.second = off;
 	} else if (dir == std::ios_base::end) {
 		const auto block_id = device_end() - 1;
-		pos.first = pos.second = block_capacity() * block_id + block_size(block_id) + off;
+		const auto size = ((get_id_ != block_id) || (put_id != block_id)) ? block_size(block_id) : 0;
+		const auto get_size = (get_id_ == block_id) ? (egptr()-eback()) : size;
+		const auto put_size = (put_id_ == block_id) ? (epptr()-pbase()) : size;
+		pos.first = block_capacity() * block_id + get_size + off;
+		pos.second = block_capacity() * block_id + put_size + off;
 	} else {
 		pos.first = block_capacity() * get_id_ + (gptr()-eback()) + off;
 		pos.second = block_capacity() * put_id_ + (pptr()-pbase()) + off;

--- a/hnswlib/graft_utils/blockbuf.h
+++ b/hnswlib/graft_utils/blockbuf.h
@@ -112,7 +112,7 @@ inline int blockbuf::sync() {
 		return 0;
 	}
 	// If the put area doesn't span a full block, we need to read the part of the block we're missing.
-	const auto offset = pptr()-pbase();
+	const size_t offset = pptr()-pbase();
 	auto size = offset;
 	if (size != blocksize_) {
 		size = read(put_id_, put_area_.data(), offset);

--- a/hnswlib/graft_utils/blockbuf.h
+++ b/hnswlib/graft_utils/blockbuf.h
@@ -109,6 +109,7 @@ inline void blockbuf::open(std::ios_base::openmode mode) {
 	// Append mode: 
 	// Position write head at end of last block, get area to fault on first read.
 	if (mode & std::ios_base::app) {
+		std::cout << "OPEN IN APPEND MODE" << std::endl;
 		get_id_ = -1;
 		setg(get_area_, get_area_, get_area_);
 		put_id_ = device_end() - 1;
@@ -172,6 +173,7 @@ inline blockbuf::pos_type blockbuf::seekpos(pos_type pos, std::ios_base::openmod
 	if (which & std::ios_base::in) {
 		int capacity = egptr()-eback();
 		if (block_id != get_id_) {
+			std::cout << "JUMP TO NEW GET AREA" << std::endl;
 			capacity = read(block_id, get_area_, 0);
 			if ((capacity == -1) || (offset > capacity)) {
 				return pos_type(off_type(-1));
@@ -186,6 +188,7 @@ inline blockbuf::pos_type blockbuf::seekpos(pos_type pos, std::ios_base::openmod
 		if (block_id != put_id_) {
 			sync();
 			put_id_ = block_id;
+			std::cout << "JUMP TO NEW PUT AREA" << std::endl;
 			const auto capacity = read(put_id_, put_area_, 0);
 			if ((capacity == -1) || (offset > capacity)) {
 				return pos_type	(off_type(-1));
@@ -196,6 +199,7 @@ inline blockbuf::pos_type blockbuf::seekpos(pos_type pos, std::ios_base::openmod
 		// Jumping past epptr(): Refresh the curent block, and reset pointers.
 		else if (offset >= (epptr()-pbase())) {
 			const auto size = pptr()-pbase();
+			std::cout << "JUMP WITHIN PUT AREA" << std::endl;
 			const auto capacity = read(put_id_, put_area_, size);
 			if ((capacity == -1) || (offset > capacity)) {
 				return pos_type	(off_type(-1));
@@ -213,6 +217,7 @@ inline blockbuf::pos_type blockbuf::seekpos(pos_type pos, std::ios_base::openmod
 }
 
 inline int blockbuf::sync() {
+	std::cout << "SYNC" << std::endl;
 	// If the dirty bit isn't set there's nothing to do.
 	if (!dirty_) {
 		return 0;
@@ -252,6 +257,7 @@ inline std::streamsize blockbuf::showmanyc() {
 }
 
 inline blockbuf::int_type blockbuf::underflow() {
+	std::cout << "UNDERFLOW" << std::endl;
 	// If this is the last block, we're at the end of file
 	if (get_id_+1 == device_end()) {
     return traits_type::eof(); 

--- a/hnswlib/graft_utils/blockbuf.h
+++ b/hnswlib/graft_utils/blockbuf.h
@@ -168,6 +168,7 @@ inline blockbuf::pos_type blockbuf::seekpos(pos_type pos, std::ios_base::openmod
 	}
 	// Get Area
 	if (which & std::ios_base::in) {
+		std::cout << "SEEKPOS " << pos << " -> " << block_id << " " << offset << " " << get_id_ << std::endl;
 		int capacity = egptr()-eback();
 		if (block_id != get_id_) {
 			capacity = read(block_id, get_area_, 0);

--- a/hnswlib/graft_utils/blockbuf.h
+++ b/hnswlib/graft_utils/blockbuf.h
@@ -118,7 +118,7 @@ inline void blockbuf::open(std::ios_base::openmode mode) {
 		if (put_id_ == 0) {
 			get_id_ = 0;
 			std::copy(pbase(), pptr(), get_area_);
-			setg(get_area_, get_area_, get_area_+(pbase()-pptr()));
+			setg(get_area_, get_area_, get_area_+(pptr()-pbase()));
 		} else {
 			get_id_ = -1;
 			setg(get_area_, get_area_, get_area_);

--- a/hnswlib/graft_utils/blockbuf.h
+++ b/hnswlib/graft_utils/blockbuf.h
@@ -151,7 +151,7 @@ inline blockbuf::pos_type blockbuf::seekoff(off_type off, std::ios_base::seekdir
 		pos.first = pos.second = off;
 	} else if (dir == std::ios_base::end) {
 		const auto block_id = device_end() - 1;
-		const auto size = ((get_id_ != block_id) || (put_id != block_id)) ? block_size(block_id) : 0;
+		const auto size = ((get_id_ != block_id) || (put_id_ != block_id)) ? block_size(block_id) : 0;
 		const auto get_size = (get_id_ == block_id) ? (egptr()-eback()) : size;
 		const auto put_size = (put_id_ == block_id) ? (epptr()-pbase()) : size;
 		pos.first = block_capacity() * block_id + get_size + off;

--- a/hnswlib/graft_utils/directorystream.h
+++ b/hnswlib/graft_utils/directorystream.h
@@ -1,0 +1,105 @@
+#ifndef GRAFT_DIRECTORYSTREAM_H
+#define GRAFT_DIRECTORYSTREAM_H
+
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <string>
+
+#include "blockbuf.h"
+
+// This class provides a concrete implementation of bufstream for debugging purposes. It uses
+// directories as a block device and creates a new file for every block.
+
+namespace graft {
+
+class directorybuf : public blockbuf {
+  public:
+    // Constructors:
+    explicit directorybuf(const std::filesystem::path& path);
+    ~directorybuf() override = default;
+
+  private:
+		int read(size_t block_id, char_type* buffer, size_t offset) override;
+		int write(size_t block_id, char_type* buffer, size_t n) override; 
+
+		std::filesystem::path get_file(size_t block_id) const;
+
+		std::filesystem::path path_;
+};
+
+class idirectorystream : public std::istream {
+  public:
+    idirectorystream(const std::filesystem::path& path);
+    ~idirectorystream() override = default;
+
+  private:
+    directorybuf buf_;
+};
+
+class odirectorystream : public std::ostream {
+  public:
+    odirectorystream(const std::filesystem::path& path);
+    ~odirectorystream() override = default;
+
+  private:
+    directorybuf buf_;
+};
+
+class directorystream : public std::iostream {
+  public:
+    directorystream(const std::filesystem::path& path);
+    ~directorystream() override = default;
+
+  private:
+    directorybuf buf_;
+};
+
+inline directorybuf::directorybuf(const std::filesystem::path& path) : blockbuf(4), path_(path) { 
+	std::filesystem::create_directory(path);
+}
+
+int directorybuf::read(size_t block_id, char_type* buffer, size_t offset) {
+	// Open backing file for this block.
+	const auto file = get_file(block_id);
+	std::ifstream ifs(file, std::ios::binary);
+	// If the file didn't open, the block doesn't exist and the size is zero.
+	if (!ifs.is_open()) {
+		return 0;
+	}
+	// Read block size
+	size_t blocksize = 0;
+	ifs.read(reinterpret_cast<char*>(&blocksize), sizeof(blocksize));
+	// Only try reading if we asked for an offset within the blocksize
+	if (offset < blocksize) {
+		ifs.seekg(offset, std::ios::cur);
+		ifs.read(buffer+offset, blocksize-offset);
+	}
+	return blocksize;
+}
+
+int directorybuf::write(size_t block_id, char_type* buffer, size_t n) {
+	// Open backing file for this block.
+	const auto file = get_file(block_id);
+	std::ofstream ofs(file, std::ios::binary);
+	// Write blocksize and new data.
+	ofs.write(reinterpret_cast<char*>(&n), sizeof(n));
+	ofs.write(buffer, n);
+	return n;
+}
+
+std::filesystem::path directorybuf::get_file(size_t block_id) const {
+	std::ostringstream oss;
+	oss << block_id;
+	return path_ / std::filesystem::path(oss.str());
+}
+
+inline idirectorystream::idirectorystream(const std::filesystem::path& path) : std::istream(&buf_), buf_(path) { }
+
+inline odirectorystream::odirectorystream(const std::filesystem::path& path) : std::ostream(&buf_), buf_(path) { }
+
+inline directorystream::directorystream(const std::filesystem::path& path) : std::iostream(&buf_), buf_(path) { }
+
+} // namespace graft
+
+#endif

--- a/hnswlib/graft_utils/directorystream.h
+++ b/hnswlib/graft_utils/directorystream.h
@@ -55,7 +55,7 @@ class directorystream : public std::iostream {
     directorybuf buf_;
 };
 
-inline directorybuf::directorybuf(const std::filesystem::path& path) : blockbuf(4), path_(path) { 
+inline directorybuf::directorybuf(const std::filesystem::path& path) : blockbuf(1024), path_(path) { 
 	std::filesystem::create_directory(path);
 }
 

--- a/hnswlib/graft_utils/directorystream.h
+++ b/hnswlib/graft_utils/directorystream.h
@@ -13,158 +13,158 @@
 
 namespace graft {
 
-class directorybuf : public blockbuf {
-  public:
-    // Constructors:
-    explicit directorybuf(const std::string& path);
-    ~directorybuf() override;
+  class directorybuf : public blockbuf {
+    public:
+      // Constructors:
+      explicit directorybuf(const std::string& path);
+      ~directorybuf() override;
 
-  private:
-		static const size_t BLOCK_SIZE = 4;
+    private:
+      static const size_t BLOCK_SIZE = 4;
 
-		size_t device_end() override;
-		void device_clear() override;
-		size_t block_capacity() override;
-		size_t block_size(size_t block_id) override;
+      size_t device_end() override;
+      void device_clear() override;
+      size_t block_capacity() override;
+      size_t block_size(size_t block_id) override;
 
-		int read(size_t block_id, char_type* buffer, size_t offset) override;
-		int write(size_t block_id, char_type* buffer, size_t n) override; 
+      int read(size_t block_id, char_type* buffer, size_t offset) override;
+      int write(size_t block_id, char_type* buffer, size_t n) override; 
 
-		// Return a path to a file in the root directory which corresponds to this block.
-		std::string get_file(size_t block_id) const;
+      // Return a path to a file in the root directory which corresponds to this block.
+      std::string get_file(size_t block_id) const;
 
-		// This path to the directory to use as a backing store.
-		std::string path_;
-};
+      // This path to the directory to use as a backing store.
+      std::string path_;
+  };
 
-class idirectorystream : public std::istream {
-  public:
-    idirectorystream(const std::string& path);
-    ~idirectorystream() override;
+  class idirectorystream : public std::istream {
+    public:
+      idirectorystream(const std::string& path);
+      ~idirectorystream() override;
 
-  private:
-    directorybuf buf_;
-};
+    private:
+      directorybuf buf_;
+  };
 
-class odirectorystream : public std::ostream {
-  public:
-    odirectorystream(const std::string& path);
-    ~odirectorystream() override;
+  class odirectorystream : public std::ostream {
+    public:
+      odirectorystream(const std::string& path);
+      ~odirectorystream() override;
 
-  private:
-    directorybuf buf_;
-};
+    private:
+      directorybuf buf_;
+  };
 
-class directorystream : public std::iostream {
-  public:
-    directorystream(const std::string& path);
-    ~directorystream() override;
+  class directorystream : public std::iostream {
+    public:
+      directorystream(const std::string& path);
+      ~directorystream() override;
 
-  private:
-    directorybuf buf_;
-};
+    private:
+      directorybuf buf_;
+  };
 
-inline directorybuf::directorybuf(const std::string& path) : 
-		blockbuf(new char_type[BLOCK_SIZE], new char_type[BLOCK_SIZE]), path_(path) {
-	// Create root directory if it doesn't already exist
-	mkdir(path.c_str(), S_IRUSR | S_IWUSR | S_IXUSR);
-}
+  inline directorybuf::directorybuf(const std::string& path) : 
+    blockbuf(new char_type[BLOCK_SIZE], new char_type[BLOCK_SIZE]), path_(path) {
+      // Create root directory if it doesn't already exist
+      mkdir(path.c_str(), S_IRUSR | S_IWUSR | S_IXUSR);
+    }
 
-inline directorybuf::~directorybuf() {
-	delete[] get_area_;
-	delete[] put_area_;
-}
+  inline directorybuf::~directorybuf() {
+    delete[] get_area_;
+    delete[] put_area_;
+  }
 
-inline size_t directorybuf::device_end() {
-	// Dictionary file is stored in block zero.
-	std::ifstream ifs(get_file(0));
-	// Return 1 if dictionary file doesn't exist.
-	if (!ifs.is_open()) {
-		return 1;
-	}
-	// Otherwise return the value stored in the file.
-	size_t res = 0;
-	ifs >> res;
-	return res;
-}
+  inline size_t directorybuf::device_end() {
+    // Dictionary file is stored in block zero.
+    std::ifstream ifs(get_file(0));
+    // Return 1 if dictionary file doesn't exist.
+    if (!ifs.is_open()) {
+      return 1;
+    }
+    // Otherwise return the value stored in the file.
+    size_t res = 0;
+    ifs >> res;
+    return res;
+  }
 
-inline void directorybuf::device_clear() {
-	// Write 1 back to block zero.
-	std::ofstream ofs(get_file(0));
-	ofs << 1;
-}
+  inline void directorybuf::device_clear() {
+    // Write 1 back to block zero.
+    std::ofstream ofs(get_file(0));
+    ofs << 1;
+  }
 
-inline size_t directorybuf::block_capacity() {
-	return BLOCK_SIZE;
-}
+  inline size_t directorybuf::block_capacity() {
+    return BLOCK_SIZE;
+  }
 
-inline size_t directorybuf::block_size(size_t block_id) {
-	return read(block_id, nullptr, block_capacity()+1);
-}
+  inline size_t directorybuf::block_size(size_t block_id) {
+    return read(block_id, nullptr, block_capacity()+1);
+  }
 
-inline int directorybuf::read(size_t block_id, char_type* buffer, size_t offset) {
-	// Open backing file for this block (id+1).
-	std::ifstream ifs(get_file(block_id+1), std::ios::binary);
-	// Reading from a block which was never written is undefined, return 0.
-	if (!ifs.is_open()) {
-		return 0;
-	}
-	// Read block size
-	size_t block_size = 0;
-	ifs.read(reinterpret_cast<char*>(&block_size), sizeof(block_size));
-	// Only try reading if we asked for an offset within the block_size
-	if (offset < block_size) {
-		ifs.seekg(offset, std::ios::cur);
-		ifs.read(buffer+offset, block_size-offset);
-	}
-	return block_size;
-}
+  inline int directorybuf::read(size_t block_id, char_type* buffer, size_t offset) {
+    // Open backing file for this block (id+1).
+    std::ifstream ifs(get_file(block_id+1), std::ios::binary);
+    // Reading from a block which was never written is undefined, return 0.
+    if (!ifs.is_open()) {
+      return 0;
+    }
+    // Read block size
+    size_t block_size = 0;
+    ifs.read(reinterpret_cast<char*>(&block_size), sizeof(block_size));
+    // Only try reading if we asked for an offset within the block_size
+    if (offset < block_size) {
+      ifs.seekg(offset, std::ios::cur);
+      ifs.read(buffer+offset, block_size-offset);
+    }
+    return block_size;
+  }
 
-inline int directorybuf::write(size_t block_id, char_type* buffer, size_t n) {
-	// Open backing file for this block (id+1).
-	const auto file = get_file(block_id+1);
-	std::ofstream ofs(file, std::ios::binary);
-	// Write blocksize and new data.
-	ofs.write(reinterpret_cast<char*>(&n), sizeof(n));
-	ofs.write(buffer, n);
-	// Update device end if necessary
-	if (block_id >= device_end()) {
-		std::ofstream ofs(get_file(0));
-		ofs << (block_id+1);
-	}
-	// Return the size of this block
-	return n;
-}
+  inline int directorybuf::write(size_t block_id, char_type* buffer, size_t n) {
+    // Open backing file for this block (id+1).
+    const auto file = get_file(block_id+1);
+    std::ofstream ofs(file, std::ios::binary);
+    // Write blocksize and new data.
+    ofs.write(reinterpret_cast<char*>(&n), sizeof(n));
+    ofs.write(buffer, n);
+    // Update device end if necessary
+    if (block_id >= device_end()) {
+      std::ofstream ofs(get_file(0));
+      ofs << (block_id+1);
+    }
+    // Return the size of this block
+    return n;
+  }
 
-std::string directorybuf::get_file(size_t block_id) const {
-	std::ostringstream oss;
-	oss << path_ << "/" << block_id;
-	return oss.str();
-}
+  std::string directorybuf::get_file(size_t block_id) const {
+    std::ostringstream oss;
+    oss << path_ << "/" << block_id;
+    return oss.str();
+  }
 
-inline idirectorystream::idirectorystream(const std::string& path) : std::istream(&buf_), buf_(path) {
-	buf_.open(std::ios_base::in | std::ios_base::app);
-}
+  inline idirectorystream::idirectorystream(const std::string& path) : std::istream(&buf_), buf_(path) {
+    buf_.open(std::ios_base::in | std::ios_base::app);
+  }
 
-inline idirectorystream::~idirectorystream() {
-	buf_.close();
-}
+  inline idirectorystream::~idirectorystream() {
+    buf_.close();
+  }
 
-inline odirectorystream::odirectorystream(const std::string& path) : std::ostream(&buf_), buf_(path) {
-	buf_.open(std::ios_base::out | std::ios_base::trunc);
-}
+  inline odirectorystream::odirectorystream(const std::string& path) : std::ostream(&buf_), buf_(path) {
+    buf_.open(std::ios_base::out | std::ios_base::trunc);
+  }
 
-inline odirectorystream::~odirectorystream() {
-	buf_.close();
-}
+  inline odirectorystream::~odirectorystream() {
+    buf_.close();
+  }
 
-inline directorystream::directorystream(const std::string& path) : std::iostream(&buf_), buf_(path) {
-	buf_.open(std::ios_base::in | std::ios_base::out | std::ios_base::app);
-}
+  inline directorystream::directorystream(const std::string& path) : std::iostream(&buf_), buf_(path) {
+    buf_.open(std::ios_base::in | std::ios_base::out | std::ios_base::app);
+  }
 
-inline directorystream::~directorystream() {
-	buf_.close();
-}
+  inline directorystream::~directorystream() {
+    buf_.close();
+  }
 
 } // namespace graft
 

--- a/hnswlib/graft_utils/s3stream.h
+++ b/hnswlib/graft_utils/s3stream.h
@@ -111,6 +111,7 @@ inline size_t s3buf::block_capacity() {
 }
 
 inline size_t s3buf::block_size(size_t block_id) {
+	std::cout << "BLOCK SIZE " << block_id << std::endl;
 	return read(block_id, nullptr, block_capacity()+1);
 }
 

--- a/hnswlib/graft_utils/s3stream.h
+++ b/hnswlib/graft_utils/s3stream.h
@@ -1,7 +1,13 @@
-#ifndef GRAFT_S3STREAM_H
+#ifndef GRAFT_S3STREAM_H 
 #define GRAFT_S3STREAM_H
 
-#include "blockstream.h"
+#include <aws/s3/S3Client.h>
+#include <aws/s3/model/GetObjectRequest.h>
+#include <aws/s3/model/PutObjectRequest.h>
+#include <sstream>
+#include <string>
+
+#include "blockbuf.h"
 
 // This class provides a c++ stream interface to s3 objects. The main complication
 // here is that s3 doesn't support appends. As a result, we treat an s3 directory
@@ -12,17 +18,32 @@ namespace graft {
 class s3buf : public blockbuf {
   public:
     // Constructors:
-    explicit s3buf();
-    ~s3buf() override = default;
+    explicit s3buf(Aws::S3::S3Client& client, const std::string& bucket, const std::string& object, std::ios_base::openmode mode);
+    ~s3buf() override;
 
   private:
-		std::streamsize read(size_t block_id, char_type* buffer) override;
-		std::streamsize write(size_t block_id, char_type* buffer, const size_t begin, const size_t end) override; 
+		static const size_t BLOCK_SIZE = 1024;
+
+		int read(size_t block_id, char_type* buffer, size_t offset) override;
+		int write(size_t block_id, char_type* buffer, size_t n) override; 
+
+		// Return a path to an object in the root bucket which corresponds to this block.
+		std::string get_key(size_t block_id) const;
+
+		// S3 Client
+		Aws::S3::S3Client& client_;
+
+		// The path to the object directory to use as a backing store.
+		std::string object_;
+
+		// Partial request objects
+		Aws::S3::Model::PutObjectRequest put_request_;
+		Aws::S3::Model::GetObjectRequest get_request_;
 };
 
-class is3dstream : public std::istream {
+class is3stream : public std::istream {
   public:
-    is3stream();
+    is3stream(Aws::S3::S3Client& client, const std::string& bucket, const std::string& object);
     ~is3stream() override = default;
 
   private:
@@ -31,7 +52,7 @@ class is3dstream : public std::istream {
 
 class os3stream : public std::ostream {
   public:
-    os3stream();
+    os3stream(Aws::S3::S3Client& client, const std::string& bucket, const std::string& object);
     ~os3stream() override = default;
 
   private:
@@ -40,28 +61,88 @@ class os3stream : public std::ostream {
 
 class s3stream : public std::iostream {
   public:
-    s3stream();
+    s3stream(Aws::S3::S3Client& client, const std::string& bucket, const std::string& object);
     ~s3stream() override = default;
 
   private:
     s3buf buf_;
 };
 
-inline s3buf::s3buf() { }
-
-std::streamsize s3buf::read(size_t block_id, char_type* buffer) {
-	return 0;
+inline s3buf::s3buf(Aws::S3::S3Client& client, const std::string& bucket, const std::string& object, std::ios_base::openmode mode) :
+		blockbuf(new char_type[BLOCK_SIZE], new char_type[BLOCK_SIZE], BLOCK_SIZE), 
+		client_(client),
+		object_(object) {
+	// Initialize request objects
+	put_request_.SetBucket(bucket);	
+  get_request_.SetBucket(bucket);
+	// Delete root object in truncate mode.
+	if (mode & std::ios_base::trunc) {
+		// TODO
+	} 
 }
 
-std::streamsize s3buf::write(size_t block_id, char_type* buffer, const size_t begin, const size_t end) {
-	return 0;
+inline s3buf::~s3buf() {
+	delete[] get_area_;
+	delete[] put_area_;
 }
 
-inline is3stream::is3stream() : std::istream(&buf_), buf_() { }
+inline int s3buf::read(size_t block_id, char_type* buffer, size_t offset) {
+	// Get path to backing file for this block.
+	const auto key = get_key(block_id);
+	get_request_.SetKey(key);
+	// Try reading the file
+	auto res = client_.GetObject(get_request_);
+	// If the file doesn't exist the block doesn't exist and the size is zero.
+	if (!res.IsSuccess()) {
+		return 0;
+	}
+	// Read block size
+  auto& content = res.GetResultWithOwnership().GetBody();
+	size_t block_size = 0;
+	content.read(reinterpret_cast<char*>(&block_size), sizeof(block_size));
+	// Only try reading if we asked for an offset within the block_size
+	if (offset < block_size) {
+		content.seekg(offset, std::ios::cur);
+		content.read(buffer+offset, block_size-offset);
+	}
+	return block_size;
+}
 
-inline os3stream::os3stream() : std::ostream(&buf_), buf_() { }
+inline int s3buf::write(size_t block_id, char_type* buffer, size_t n) {
+	// Get path to backing file for this block.
+	const auto key = get_key(block_id);
+	put_request_.SetKey(key);
+	// Write blocksize and new data.
+	const auto mode = std::ios::binary | std::ios::in | std::ios::out;
+  std::shared_ptr<Aws::StringStream> input_data = Aws::MakeShared<Aws::StringStream>("SampleAllocationTag", mode);
+	input_data->write(reinterpret_cast<char*>(&n), sizeof(n));
+	input_data->write(buffer, n);
+	put_request_.SetBody(input_data);
+	// Check results for failure, otherwise return block size
+  const auto res = client_.PutObject(put_request_);
+	return res.IsSuccess() ? n : -1;
+}
 
-inline s3stream::s3stream() : std::iostream(&buf_), buf_() { }
+inline std::string s3buf::get_key(size_t block_id) const {
+	std::ostringstream oss;
+	oss << object_ << "/" << block_id;
+	return oss.str();
+}
+
+inline is3stream::is3stream(Aws::S3::S3Client& client, const std::string& bucket, const std::string& object) : 
+	std::istream(&buf_), 
+	buf_(client, bucket, object, std::ios_base::in | std::ios_base::app) { 
+}
+
+inline os3stream::os3stream(Aws::S3::S3Client& client, const std::string& bucket, const std::string& object) : 
+	std::ostream(&buf_), 
+	buf_(client, bucket, object, std::ios_base::out | std::ios_base::trunc) { 
+}
+
+inline s3stream::s3stream(Aws::S3::S3Client& client, const std::string& bucket, const std::string& object) : 
+	std::iostream(&buf_), 
+	buf_(client, bucket, object, std::ios_base::in | std::ios_base::out | std::ios_base::app) { 
+}
 
 } // namespace graft
 

--- a/hnswlib/graft_utils/s3stream.h
+++ b/hnswlib/graft_utils/s3stream.h
@@ -24,7 +24,7 @@ class s3buf : public blockbuf {
     ~s3buf() override;
 
   private:
-		static const size_t BLOCK_SIZE = 4;//32 * 1024 * 1024; // 32MB
+		static const size_t BLOCK_SIZE = 32 * 1024 * 1024; // 32MB
 
 		int read(size_t block_id, char_type* buffer, size_t offset) override;
 		int write(size_t block_id, char_type* buffer, size_t n) override; 

--- a/hnswlib/graft_utils/s3stream.h
+++ b/hnswlib/graft_utils/s3stream.h
@@ -1,0 +1,68 @@
+#ifndef GRAFT_S3STREAM_H
+#define GRAFT_S3STREAM_H
+
+#include "blockstream.h"
+
+// This class provides a c++ stream interface to s3 objects. The main complication
+// here is that s3 doesn't support appends. As a result, we treat an s3 directory
+// as a block device where a file is spread out across multiple blocks.
+
+namespace graft {
+
+class s3buf : public blockbuf {
+  public:
+    // Constructors:
+    explicit s3buf();
+    ~s3buf() override = default;
+
+  private:
+		std::streamsize read(size_t block_id, char_type* buffer) override;
+		std::streamsize write(size_t block_id, char_type* buffer, const size_t begin, const size_t end) override; 
+};
+
+class is3dstream : public std::istream {
+  public:
+    is3stream();
+    ~is3stream() override = default;
+
+  private:
+    s3buf buf_;
+};
+
+class os3stream : public std::ostream {
+  public:
+    os3stream();
+    ~os3stream() override = default;
+
+  private:
+    s3buf buf_;
+};
+
+class s3stream : public std::iostream {
+  public:
+    s3stream();
+    ~s3stream() override = default;
+
+  private:
+    s3buf buf_;
+};
+
+inline s3buf::s3buf() { }
+
+std::streamsize s3buf::read(size_t block_id, char_type* buffer) {
+	return 0;
+}
+
+std::streamsize s3buf::write(size_t block_id, char_type* buffer, const size_t begin, const size_t end) {
+	return 0;
+}
+
+inline is3stream::is3stream() : std::istream(&buf_), buf_() { }
+
+inline os3stream::os3stream() : std::ostream(&buf_), buf_() { }
+
+inline s3stream::s3stream() : std::iostream(&buf_), buf_() { }
+
+} // namespace graft
+
+#endif

--- a/hnswlib/graft_utils/s3stream.h
+++ b/hnswlib/graft_utils/s3stream.h
@@ -115,6 +115,7 @@ inline size_t s3buf::block_size(size_t block_id) {
 }
 
 inline int s3buf::read(size_t block_id, char_type* buffer, size_t offset) {
+	std::cout << "READ " << block_id << std::endl;
 	// Open backing file for this block (id+1)
 	get_request_.SetKey(get_key(block_id+1));
 	auto res = client_.GetObject(get_request_);
@@ -135,6 +136,7 @@ inline int s3buf::read(size_t block_id, char_type* buffer, size_t offset) {
 }
 
 inline int s3buf::write(size_t block_id, char_type* buffer, size_t n) {
+	std::cout << "WRITE " << block_id << std::endl;
 	// Open backing file for this block (id+1).
 	put_request_.SetKey(get_key(block_id+1));
 	// Write blocksize and new data.

--- a/hnswlib/graft_utils/s3stream.h
+++ b/hnswlib/graft_utils/s3stream.h
@@ -2,9 +2,7 @@
 #define GRAFT_S3STREAM_H
 
 #include <aws/s3/S3Client.h>
-#include <aws/s3/model/DeleteObjectRequest.h>
 #include <aws/s3/model/GetObjectRequest.h>
-#include <aws/s3/model/ListObjectsV2Request.h>
 #include <aws/s3/model/PutObjectRequest.h>
 #include <sstream>
 #include <string>
@@ -20,26 +18,36 @@ namespace graft {
 class s3buf : public blockbuf {
   public:
     // Constructors:
-    explicit s3buf(Aws::S3::S3Client& client, const std::string& bucket, const std::string& object, std::ios_base::openmode mode);
+    explicit s3buf(Aws::S3::S3Client& client, const std::string& bucket, const std::string& object);
     ~s3buf() override;
 
   private:
 		static const size_t BLOCK_SIZE = 32 * 1024 * 1024; // 32MB
 
+		size_t device_end() override;
+		void device_clear() override;
+		size_t block_capacity() override;
+		size_t block_size(size_t block_id) override;
+
 		int read(size_t block_id, char_type* buffer, size_t offset) override;
 		int write(size_t block_id, char_type* buffer, size_t n) override; 
 
-		// Delete files in a bucket with a prefix
-		void delete_all(const std::string& bucket, const std::string& object);
-
 		// Return a path to an object in the root bucket which corresponds to this block.
 		std::string get_key(size_t block_id) const;
+
+		// Helper methods for tracking device end.
+		size_t read_cached_device_end();
+		void set_cached_device_end(size_t id);
+		void write_cached_device_end();
 
 		// S3 Client
 		Aws::S3::S3Client& client_;
 
 		// The path to the object directory to use as a backing store.
 		std::string object_;
+
+		// A cached copy of the contents of block 0
+		size_t device_end_;
 
 		// Partial request objects
 		Aws::S3::Model::PutObjectRequest put_request_;
@@ -49,7 +57,7 @@ class s3buf : public blockbuf {
 class is3stream : public std::istream {
   public:
     is3stream(Aws::S3::S3Client& client, const std::string& bucket, const std::string& object);
-    ~is3stream() override = default;
+    ~is3stream() override;
 
   private:
     s3buf buf_;
@@ -58,7 +66,7 @@ class is3stream : public std::istream {
 class os3stream : public std::ostream {
   public:
     os3stream(Aws::S3::S3Client& client, const std::string& bucket, const std::string& object);
-    ~os3stream() override = default;
+    ~os3stream() override;
 
   private:
     s3buf buf_;
@@ -67,94 +75,81 @@ class os3stream : public std::ostream {
 class s3stream : public std::iostream {
   public:
     s3stream(Aws::S3::S3Client& client, const std::string& bucket, const std::string& object);
-    ~s3stream() override = default;
+    ~s3stream() override;
 
   private:
     s3buf buf_;
 };
 
-inline s3buf::s3buf(Aws::S3::S3Client& client, const std::string& bucket, const std::string& object, std::ios_base::openmode mode) :
-		blockbuf(new char_type[BLOCK_SIZE], new char_type[BLOCK_SIZE], BLOCK_SIZE), 
-		client_(client),
-		object_(object) {
+inline s3buf::s3buf(Aws::S3::S3Client& client, const std::string& bucket, const std::string& object) :
+		blockbuf(new char_type[BLOCK_SIZE], new char_type[BLOCK_SIZE]), client_(client), object_(object) {
 	// Initialize request objects
 	put_request_.SetBucket(bucket);	
   get_request_.SetBucket(bucket);
-	// Delete root object in truncate mode.
-	if (mode & std::ios_base::trunc) {
-		delete_all(bucket, object);
-	}
+	// Initialize device_end to sentinel value
+	device_end_ = 0;
 }
 
 inline s3buf::~s3buf() {
+	// Free get/put areas.
 	delete[] get_area_;
 	delete[] put_area_;
+	// Write back device end
+	write_cached_device_end();
+}
+
+inline size_t s3buf::device_end() {
+	return read_cached_device_end();
+}
+
+inline void s3buf::device_clear() {
+	set_cached_device_end(1);
+}
+
+inline size_t s3buf::block_capacity() {
+	return BLOCK_SIZE;
+}
+
+inline size_t s3buf::block_size(size_t block_id) {
+	return read(block_id, nullptr, block_capacity()+1);
 }
 
 inline int s3buf::read(size_t block_id, char_type* buffer, size_t offset) {
-	// Get path to backing file for this block.
-	const auto key = get_key(block_id);
-	get_request_.SetKey(key);
-	// Try reading the file
+	// Open backing file for this block (id+1)
+	get_request_.SetKey(get_key(block_id+1));
 	auto res = client_.GetObject(get_request_);
-	// If the file doesn't exist the block doesn't exist and the size is zero.
+	// Reading from a block which was never written is undefined, return 0.
 	if (!res.IsSuccess()) {
 		return 0;
 	}
 	// Read block size
-  auto& content = res.GetResult().GetBody();
+  auto& ss = res.GetResult().GetBody();
 	size_t block_size = 0;
-	content.read(reinterpret_cast<char*>(&block_size), sizeof(block_size));
+	ss.read(reinterpret_cast<char*>(&block_size), sizeof(block_size));
 	// Only try reading if we asked for an offset within the block_size
 	if (offset < block_size) {
-		content.seekg(offset, std::ios::cur);
-		content.read(buffer+offset, block_size-offset);
+		ss.seekg(offset, std::ios::cur);
+		ss.read(buffer+offset, block_size-offset);
 	}
 	return block_size;
 }
 
 inline int s3buf::write(size_t block_id, char_type* buffer, size_t n) {
-	// Get path to backing file for this block.
-	const auto key = get_key(block_id);
-	put_request_.SetKey(key);
+	// Open backing file for this block (id+1).
+	put_request_.SetKey(get_key(block_id+1));
 	// Write blocksize and new data.
 	const auto mode = std::ios::binary | std::ios::in | std::ios::out;
-  std::shared_ptr<Aws::StringStream> input_data = Aws::MakeShared<Aws::StringStream>("SampleAllocationTag", mode);
-	input_data->write(reinterpret_cast<char*>(&n), sizeof(n));
-	input_data->write(buffer, n);
-	put_request_.SetBody(input_data);
-	// Check results for failure, otherwise return block size
-  const auto res = client_.PutObject(put_request_);
-	return res.IsSuccess() ? n : -1;
-}
-
-inline void s3buf::delete_all(const std::string& bucket, const std::string& object) {
-	// Prepare request objects
-	Aws::S3::Model::ListObjectsV2Request list_request;
-	list_request.WithBucket(bucket).WithPrefix(object).WithMaxKeys(2);
-	Aws::S3::Model::DeleteObjectRequest delete_request;
-	delete_request.WithBucket(bucket);
-
-	while (true) {
-		// Submit the next list request (we can receive at most 1000 results at a time)
-		const auto list_res = client_.ListObjectsV2(list_request);
-		if (!list_res.IsSuccess()) {
-			return;
-		}
-		// Delete objects in this batch
-		for (auto& obj : list_res.GetResult().GetContents()) {
-			delete_request.WithKey(obj.GetKey());
-			if (!client_.DeleteObject(delete_request).IsSuccess()) {
-				return;
-			}
-		}
-		// Set continuation token if there are more results, otherwise we're done. 
-		if (list_res.GetResult().GetIsTruncated()) {
-			list_request.SetContinuationToken(list_res.GetResult().GetNextContinuationToken());			
-		} else {
-			return;
-		}
+  std::shared_ptr<Aws::StringStream> ss = Aws::MakeShared<Aws::StringStream>("SampleAllocationTag", mode);
+	ss->write(reinterpret_cast<char*>(&n), sizeof(n));
+	ss->write(buffer, n);
+	put_request_.SetBody(ss);
+  client_.PutObject(put_request_);
+	// Update device end if necessary
+	if (block_id >= read_cached_device_end()) {
+		set_cached_device_end(block_id+1);
 	}
+	// Return the size of this block
+	return n;
 }
 
 inline std::string s3buf::get_key(size_t block_id) const {
@@ -163,19 +158,64 @@ inline std::string s3buf::get_key(size_t block_id) const {
 	return oss.str();
 }
 
+inline size_t s3buf::read_cached_device_end() {
+	// Check block zero only if device_end_ is the sentinel value.
+	if (device_end_ == 0) {
+		get_request_.SetKey(get_key(0));
+		auto res = client_.GetObject(get_request_);
+		if (!res.IsSuccess()) {
+			device_end_ = 1;
+		} 
+		else {
+			auto& ss = res.GetResult().GetBody();
+			ss >> device_end_;
+		}
+	}
+	return device_end_;
+}
+
+
+inline void s3buf::set_cached_device_end(size_t id) {
+	device_end_ = id;
+}
+
+inline void s3buf::write_cached_device_end() {
+	// Write block zero only if device_end_ is the sentinel value.
+	if (device_end_ != 0) {
+		put_request_.SetKey(get_key(0));
+		const auto mode = std::ios::binary | std::ios::in | std::ios::out;
+		std::shared_ptr<Aws::StringStream> ss = Aws::MakeShared<Aws::StringStream>("SampleAllocationTag", mode);
+		*ss << device_end_;
+		put_request_.SetBody(ss);
+		client_.PutObject(put_request_);
+	}
+}
+
 inline is3stream::is3stream(Aws::S3::S3Client& client, const std::string& bucket, const std::string& object) : 
-	std::istream(&buf_), 
-	buf_(client, bucket, object, std::ios_base::in | std::ios_base::app) { 
+		std::istream(&buf_), buf_(client, bucket, object) {
+	buf_.open(std::ios_base::in | std::ios_base::app);
+}
+
+inline is3stream::~is3stream() {
+	buf_.close();
 }
 
 inline os3stream::os3stream(Aws::S3::S3Client& client, const std::string& bucket, const std::string& object) : 
-	std::ostream(&buf_), 
-	buf_(client, bucket, object, std::ios_base::out | std::ios_base::trunc) { 
+		std::ostream(&buf_), buf_(client, bucket, object) {
+	buf_.open(std::ios_base::out | std::ios_base::trunc);
+}
+
+inline os3stream::~os3stream() {
+	buf_.close();
 }
 
 inline s3stream::s3stream(Aws::S3::S3Client& client, const std::string& bucket, const std::string& object) : 
-	std::iostream(&buf_), 
-	buf_(client, bucket, object, std::ios_base::in | std::ios_base::out | std::ios_base::app) { 
+		std::iostream(&buf_), buf_(client, bucket, object) {
+	buf_.open(std::ios_base::in | std::ios_base::out | std::ios_base::app);
+}
+
+inline s3stream::~s3stream() {
+	buf_.close();
 }
 
 } // namespace graft

--- a/hnswlib/graft_utils/s3stream.h
+++ b/hnswlib/graft_utils/s3stream.h
@@ -111,12 +111,10 @@ inline size_t s3buf::block_capacity() {
 }
 
 inline size_t s3buf::block_size(size_t block_id) {
-	std::cout << "BLOCK SIZE " << block_id << std::endl;
 	return read(block_id, nullptr, block_capacity()+1);
 }
 
 inline int s3buf::read(size_t block_id, char_type* buffer, size_t offset) {
-	std::cout << "READ " << block_id << std::endl;
 	// Open backing file for this block (id+1)
 	get_request_.SetKey(get_key(block_id+1));
 	auto res = client_.GetObject(get_request_);
@@ -137,7 +135,6 @@ inline int s3buf::read(size_t block_id, char_type* buffer, size_t offset) {
 }
 
 inline int s3buf::write(size_t block_id, char_type* buffer, size_t n) {
-	std::cout << "WRITE " << block_id << std::endl;
 	// Open backing file for this block (id+1).
 	put_request_.SetKey(get_key(block_id+1));
 	// Write blocksize and new data.

--- a/hnswlib/graft_utils/s3stream.h
+++ b/hnswlib/graft_utils/s3stream.h
@@ -168,7 +168,7 @@ inline size_t s3buf::read_cached_device_end() {
 		} 
 		else {
 			auto& ss = res.GetResult().GetBody();
-			ss >> device_end_;
+			ss.read(reinterpret_cast<char*>(&device_end_), sizeof(device_end_));
 		}
 	}
 	return device_end_;
@@ -185,7 +185,7 @@ inline void s3buf::write_cached_device_end() {
 		put_request_.SetKey(get_key(0));
 		const auto mode = std::ios::binary | std::ios::in | std::ios::out;
 		std::shared_ptr<Aws::StringStream> ss = Aws::MakeShared<Aws::StringStream>("SampleAllocationTag", mode);
-		*ss << device_end_;
+		ss->write(reinterpret_cast<char*>(&device_end_), sizeof(device_end_));
 		put_request_.SetBody(ss);
 		client_.PutObject(put_request_);
 	}

--- a/hnswlib/graft_utils/s3stream.h
+++ b/hnswlib/graft_utils/s3stream.h
@@ -115,7 +115,6 @@ inline size_t s3buf::block_size(size_t block_id) {
 }
 
 inline int s3buf::read(size_t block_id, char_type* buffer, size_t offset) {
-	std::cout << "READ " << block_id << std::endl;
 	// Open backing file for this block (id+1)
 	get_request_.SetKey(get_key(block_id+1));
 	auto res = client_.GetObject(get_request_);
@@ -136,7 +135,6 @@ inline int s3buf::read(size_t block_id, char_type* buffer, size_t offset) {
 }
 
 inline int s3buf::write(size_t block_id, char_type* buffer, size_t n) {
-	std::cout << "WRITE " << block_id << std::endl;
 	// Open backing file for this block (id+1).
 	put_request_.SetKey(get_key(block_id+1));
 	// Write blocksize and new data.

--- a/hnswlib/graft_utils/s3stream.h
+++ b/hnswlib/graft_utils/s3stream.h
@@ -15,208 +15,208 @@
 
 namespace graft {
 
-class s3buf : public blockbuf {
-  public:
-    // Constructors:
-    explicit s3buf(Aws::S3::S3Client& client, const std::string& bucket, const std::string& object);
-    ~s3buf() override;
+  class s3buf : public blockbuf {
+    public:
+      // Constructors:
+      explicit s3buf(Aws::S3::S3Client& client, const std::string& bucket, const std::string& object);
+      ~s3buf() override;
 
-  private:
-		static const size_t BLOCK_SIZE = 32 * 1024 * 1024; // 32MB
+    private:
+      static const size_t BLOCK_SIZE = 32 * 1024 * 1024; // 32MB
 
-		size_t device_end() override;
-		void device_clear() override;
-		size_t block_capacity() override;
-		size_t block_size(size_t block_id) override;
+      size_t device_end() override;
+      void device_clear() override;
+      size_t block_capacity() override;
+      size_t block_size(size_t block_id) override;
 
-		int read(size_t block_id, char_type* buffer, size_t offset) override;
-		int write(size_t block_id, char_type* buffer, size_t n) override; 
+      int read(size_t block_id, char_type* buffer, size_t offset) override;
+      int write(size_t block_id, char_type* buffer, size_t n) override; 
 
-		// Return a path to an object in the root bucket which corresponds to this block.
-		std::string get_key(size_t block_id) const;
+      // Return a path to an object in the root bucket which corresponds to this block.
+      std::string get_key(size_t block_id) const;
 
-		// Helper methods for tracking device end.
-		size_t read_cached_device_end();
-		void set_cached_device_end(size_t id);
-		void write_cached_device_end();
+      // Helper methods for tracking device end.
+      size_t read_cached_device_end();
+      void set_cached_device_end(size_t id);
+      void write_cached_device_end();
 
-		// S3 Client
-		Aws::S3::S3Client& client_;
+      // S3 Client
+      Aws::S3::S3Client& client_;
 
-		// The path to the object directory to use as a backing store.
-		std::string object_;
+      // The path to the object directory to use as a backing store.
+      std::string object_;
 
-		// A cached copy of the contents of block 0
-		size_t device_end_;
+      // A cached copy of the contents of block 0
+      size_t device_end_;
 
-		// Partial request objects
-		Aws::S3::Model::PutObjectRequest put_request_;
-		Aws::S3::Model::GetObjectRequest get_request_;
-};
+      // Partial request objects
+      Aws::S3::Model::PutObjectRequest put_request_;
+      Aws::S3::Model::GetObjectRequest get_request_;
+  };
 
-class is3stream : public std::istream {
-  public:
-    is3stream(Aws::S3::S3Client& client, const std::string& bucket, const std::string& object);
-    ~is3stream() override;
+  class is3stream : public std::istream {
+    public:
+      is3stream(Aws::S3::S3Client& client, const std::string& bucket, const std::string& object);
+      ~is3stream() override;
 
-  private:
-    s3buf buf_;
-};
+    private:
+      s3buf buf_;
+  };
 
-class os3stream : public std::ostream {
-  public:
-    os3stream(Aws::S3::S3Client& client, const std::string& bucket, const std::string& object);
-    ~os3stream() override;
+  class os3stream : public std::ostream {
+    public:
+      os3stream(Aws::S3::S3Client& client, const std::string& bucket, const std::string& object);
+      ~os3stream() override;
 
-  private:
-    s3buf buf_;
-};
+    private:
+      s3buf buf_;
+  };
 
-class s3stream : public std::iostream {
-  public:
-    s3stream(Aws::S3::S3Client& client, const std::string& bucket, const std::string& object);
-    ~s3stream() override;
+  class s3stream : public std::iostream {
+    public:
+      s3stream(Aws::S3::S3Client& client, const std::string& bucket, const std::string& object);
+      ~s3stream() override;
 
-  private:
-    s3buf buf_;
-};
+    private:
+      s3buf buf_;
+  };
 
-inline s3buf::s3buf(Aws::S3::S3Client& client, const std::string& bucket, const std::string& object) :
-		blockbuf(new char_type[BLOCK_SIZE], new char_type[BLOCK_SIZE]), client_(client), object_(object) {
-	// Initialize request objects
-	put_request_.SetBucket(bucket);	
-  get_request_.SetBucket(bucket);
-	// Initialize device_end to sentinel value
-	device_end_ = 0;
-}
+  inline s3buf::s3buf(Aws::S3::S3Client& client, const std::string& bucket, const std::string& object) :
+    blockbuf(new char_type[BLOCK_SIZE], new char_type[BLOCK_SIZE]), client_(client), object_(object) {
+      // Initialize request objects
+      put_request_.SetBucket(bucket);	
+      get_request_.SetBucket(bucket);
+      // Initialize device_end to sentinel value
+      device_end_ = 0;
+    }
 
-inline s3buf::~s3buf() {
-	// Free get/put areas.
-	delete[] get_area_;
-	delete[] put_area_;
-	// Write back device end
-	write_cached_device_end();
-}
+  inline s3buf::~s3buf() {
+    // Free get/put areas.
+    delete[] get_area_;
+    delete[] put_area_;
+    // Write back device end
+    write_cached_device_end();
+  }
 
-inline size_t s3buf::device_end() {
-	return read_cached_device_end();
-}
+  inline size_t s3buf::device_end() {
+    return read_cached_device_end();
+  }
 
-inline void s3buf::device_clear() {
-	set_cached_device_end(1);
-}
+  inline void s3buf::device_clear() {
+    set_cached_device_end(1);
+  }
 
-inline size_t s3buf::block_capacity() {
-	return BLOCK_SIZE;
-}
+  inline size_t s3buf::block_capacity() {
+    return BLOCK_SIZE;
+  }
 
-inline size_t s3buf::block_size(size_t block_id) {
-	return read(block_id, nullptr, block_capacity()+1);
-}
+  inline size_t s3buf::block_size(size_t block_id) {
+    return read(block_id, nullptr, block_capacity()+1);
+  }
 
-inline int s3buf::read(size_t block_id, char_type* buffer, size_t offset) {
-	// Open backing file for this block (id+1)
-	get_request_.SetKey(get_key(block_id+1));
-	auto res = client_.GetObject(get_request_);
-	// Reading from a block which was never written is undefined, return 0.
-	if (!res.IsSuccess()) {
-		return 0;
-	}
-	// Read block size
-  auto& ss = res.GetResult().GetBody();
-	size_t block_size = 0;
-	ss.read(reinterpret_cast<char*>(&block_size), sizeof(block_size));
-	// Only try reading if we asked for an offset within the block_size
-	if (offset < block_size) {
-		ss.seekg(offset, std::ios::cur);
-		ss.read(buffer+offset, block_size-offset);
-	}
-	return block_size;
-}
+  inline int s3buf::read(size_t block_id, char_type* buffer, size_t offset) {
+    // Open backing file for this block (id+1)
+    get_request_.SetKey(get_key(block_id+1));
+    auto res = client_.GetObject(get_request_);
+    // Reading from a block which was never written is undefined, return 0.
+    if (!res.IsSuccess()) {
+      return 0;
+    }
+    // Read block size
+    auto& ss = res.GetResult().GetBody();
+    size_t block_size = 0;
+    ss.read(reinterpret_cast<char*>(&block_size), sizeof(block_size));
+    // Only try reading if we asked for an offset within the block_size
+    if (offset < block_size) {
+      ss.seekg(offset, std::ios::cur);
+      ss.read(buffer+offset, block_size-offset);
+    }
+    return block_size;
+  }
 
-inline int s3buf::write(size_t block_id, char_type* buffer, size_t n) {
-	// Open backing file for this block (id+1).
-	put_request_.SetKey(get_key(block_id+1));
-	// Write blocksize and new data.
-	const auto mode = std::ios::binary | std::ios::in | std::ios::out;
-  std::shared_ptr<Aws::StringStream> ss = Aws::MakeShared<Aws::StringStream>("SampleAllocationTag", mode);
-	ss->write(reinterpret_cast<char*>(&n), sizeof(n));
-	ss->write(buffer, n);
-	put_request_.SetBody(ss);
-  client_.PutObject(put_request_);
-	// Update device end if necessary
-	if (block_id >= read_cached_device_end()) {
-		set_cached_device_end(block_id+1);
-	}
-	// Return the size of this block
-	return n;
-}
+  inline int s3buf::write(size_t block_id, char_type* buffer, size_t n) {
+    // Open backing file for this block (id+1).
+    put_request_.SetKey(get_key(block_id+1));
+    // Write blocksize and new data.
+    const auto mode = std::ios::binary | std::ios::in | std::ios::out;
+    std::shared_ptr<Aws::StringStream> ss = Aws::MakeShared<Aws::StringStream>("SampleAllocationTag", mode);
+    ss->write(reinterpret_cast<char*>(&n), sizeof(n));
+    ss->write(buffer, n);
+    put_request_.SetBody(ss);
+    client_.PutObject(put_request_);
+    // Update device end if necessary
+    if (block_id >= read_cached_device_end()) {
+      set_cached_device_end(block_id+1);
+    }
+    // Return the size of this block
+    return n;
+  }
 
-inline std::string s3buf::get_key(size_t block_id) const {
-	std::ostringstream oss;
-	oss << object_ << "/" << block_id;
-	return oss.str();
-}
+  inline std::string s3buf::get_key(size_t block_id) const {
+    std::ostringstream oss;
+    oss << object_ << "/" << block_id;
+    return oss.str();
+  }
 
-inline size_t s3buf::read_cached_device_end() {
-	// Check block zero only if device_end_ is the sentinel value.
-	if (device_end_ == 0) {
-		get_request_.SetKey(get_key(0));
-		auto res = client_.GetObject(get_request_);
-		if (!res.IsSuccess()) {
-			device_end_ = 1;
-		} 
-		else {
-			auto& ss = res.GetResult().GetBody();
-			ss.read(reinterpret_cast<char*>(&device_end_), sizeof(device_end_));
-		}
-	}
-	return device_end_;
-}
+  inline size_t s3buf::read_cached_device_end() {
+    // Check block zero only if device_end_ is the sentinel value.
+    if (device_end_ == 0) {
+      get_request_.SetKey(get_key(0));
+      auto res = client_.GetObject(get_request_);
+      if (!res.IsSuccess()) {
+        device_end_ = 1;
+      } 
+      else {
+        auto& ss = res.GetResult().GetBody();
+        ss.read(reinterpret_cast<char*>(&device_end_), sizeof(device_end_));
+      }
+    }
+    return device_end_;
+  }
 
 
-inline void s3buf::set_cached_device_end(size_t id) {
-	device_end_ = id;
-}
+  inline void s3buf::set_cached_device_end(size_t id) {
+    device_end_ = id;
+  }
 
-inline void s3buf::write_cached_device_end() {
-	// Write block zero only if device_end_ is the sentinel value.
-	if (device_end_ != 0) {
-		put_request_.SetKey(get_key(0));
-		const auto mode = std::ios::binary | std::ios::in | std::ios::out;
-		std::shared_ptr<Aws::StringStream> ss = Aws::MakeShared<Aws::StringStream>("SampleAllocationTag", mode);
-		ss->write(reinterpret_cast<char*>(&device_end_), sizeof(device_end_));
-		put_request_.SetBody(ss);
-		client_.PutObject(put_request_);
-	}
-}
+  inline void s3buf::write_cached_device_end() {
+    // Write block zero only if device_end_ is the sentinel value.
+    if (device_end_ != 0) {
+      put_request_.SetKey(get_key(0));
+      const auto mode = std::ios::binary | std::ios::in | std::ios::out;
+      std::shared_ptr<Aws::StringStream> ss = Aws::MakeShared<Aws::StringStream>("SampleAllocationTag", mode);
+      ss->write(reinterpret_cast<char*>(&device_end_), sizeof(device_end_));
+      put_request_.SetBody(ss);
+      client_.PutObject(put_request_);
+    }
+  }
 
-inline is3stream::is3stream(Aws::S3::S3Client& client, const std::string& bucket, const std::string& object) : 
-		std::istream(&buf_), buf_(client, bucket, object) {
-	buf_.open(std::ios_base::in | std::ios_base::app);
-}
+  inline is3stream::is3stream(Aws::S3::S3Client& client, const std::string& bucket, const std::string& object) : 
+    std::istream(&buf_), buf_(client, bucket, object) {
+      buf_.open(std::ios_base::in | std::ios_base::app);
+    }
 
-inline is3stream::~is3stream() {
-	buf_.close();
-}
+  inline is3stream::~is3stream() {
+    buf_.close();
+  }
 
-inline os3stream::os3stream(Aws::S3::S3Client& client, const std::string& bucket, const std::string& object) : 
-		std::ostream(&buf_), buf_(client, bucket, object) {
-	buf_.open(std::ios_base::out | std::ios_base::trunc);
-}
+  inline os3stream::os3stream(Aws::S3::S3Client& client, const std::string& bucket, const std::string& object) : 
+    std::ostream(&buf_), buf_(client, bucket, object) {
+      buf_.open(std::ios_base::out | std::ios_base::trunc);
+    }
 
-inline os3stream::~os3stream() {
-	buf_.close();
-}
+  inline os3stream::~os3stream() {
+    buf_.close();
+  }
 
-inline s3stream::s3stream(Aws::S3::S3Client& client, const std::string& bucket, const std::string& object) : 
-		std::iostream(&buf_), buf_(client, bucket, object) {
-	buf_.open(std::ios_base::in | std::ios_base::out | std::ios_base::app);
-}
+  inline s3stream::s3stream(Aws::S3::S3Client& client, const std::string& bucket, const std::string& object) : 
+    std::iostream(&buf_), buf_(client, bucket, object) {
+      buf_.open(std::ios_base::in | std::ios_base::out | std::ios_base::app);
+    }
 
-inline s3stream::~s3stream() {
-	buf_.close();
-}
+  inline s3stream::~s3stream() {
+    buf_.close();
+  }
 
 } // namespace graft
 

--- a/hnswlib/hnswalg.h
+++ b/hnswlib/hnswalg.h
@@ -741,12 +741,12 @@ namespace hnswlib {
             ifs.close();
         }
 
-        void saveIndex(const std::string& region, const std::string& bucket, const std::string& object, SpaceInterface<dist_t> *s, size_t max_elements_i=0) {
+        void loadIndex(const std::string& region, const std::string& bucket, const std::string& object, SpaceInterface<dist_t> *s, size_t max_elements_i=0) {
             ensure_aws();
             Aws::Client::ClientConfiguration config;
             config.region = region;
             Aws::S3::S3Client client(config);
-            graft::is3stream is3s(client, BUCKET, OBJECT);
+            graft::is3stream is3s(client, bucket, object);
             loadIndex(is3s, s, max_elements_i);
         }
 

--- a/hnswlib/hnswalg.h
+++ b/hnswlib/hnswalg.h
@@ -9,6 +9,9 @@
 #include <unordered_set>
 #include <list>
 
+//TODO(eschkufz): DELETE ME
+#include <iostream>
+
 namespace hnswlib {
     typedef unsigned int tableint;
     typedef unsigned int linklistsizeint;
@@ -586,6 +589,7 @@ namespace hnswlib {
         }
 
         void saveIndex(const std::string &location) {
+            std::cout << "Saving index" << std::endl;
             std::ofstream output(location, std::ios::binary);
             std::streampos position;
 

--- a/hnswlib/hnswalg.h
+++ b/hnswlib/hnswalg.h
@@ -10,6 +10,7 @@
 #include <unordered_set>
 #include <list>
 
+#include <cstdlib> // delete me
 #include "graft_utils/directorystream.h"
 
 namespace hnswlib {
@@ -619,6 +620,9 @@ namespace hnswlib {
             //saveIndex(ofs);
             //ofs.close();
 
+						std::ostringstream oss;
+						oss << "rm -rf " << location;
+						std::system(oss.str().c_str());
             graft::odirectorystream ods(location);
             saveIndex(ods);
             ods.flush();
@@ -730,6 +734,9 @@ namespace hnswlib {
             //loadIndex(ifs, s, max_elements_i);
             //ifs.close();
 
+						std::ostringstream oss;
+						oss << "rm -rf " << location;
+						std::system(oss.str().c_str());
             graft::idirectorystream ids(location);
             loadIndex(ids, s, max_elements_i);
         }

--- a/hnswlib/hnswalg.h
+++ b/hnswlib/hnswalg.h
@@ -588,16 +588,6 @@ namespace hnswlib {
             max_elements_ = new_max_elements;
         }
 
-        void saveIndex(const std::string &location) {
-            //std::ofstream ofs(location, std::ios::binary);
-            //saveIndex(ofs);
-            //ofs.close();
-
-            graft::odirectorystream ods(location);
-            saveIndex(ods);
-            ods.flush();
-        }
-
         void saveIndex(std::ostream& os) {
             writeBinaryPOD(os, offsetLevel0_);
             writeBinaryPOD(os, max_elements_);
@@ -624,15 +614,14 @@ namespace hnswlib {
             }
         }
 
-        void loadIndex(const std::string &location, SpaceInterface<dist_t> *s, size_t max_elements_i=0) {
-            //std::ifstream ifs(location, std::ios::binary);
-            //if (!ifs.is_open())
-            //    throw std::runtime_error("Cannot open file");
-            //loadIndex(ifs, s, max_elements_i);
-            //ifs.close();
+         void saveIndex(const std::string &location) {
+            //std::ofstream ofs(location, std::ios::binary);
+            //saveIndex(ofs);
+            //ofs.close();
 
-            graft::idirectorystream ids(location);
-            LoadIndex(ids, s, max_elements_i);
+            graft::odirectorystream ods(location);
+            saveIndex(ods);
+            ods.flush();
         }
 
         void loadIndex(std::istream& is, SpaceInterface<dist_t> *s, size_t max_elements_i) {
@@ -732,6 +721,17 @@ namespace hnswlib {
                 if(isMarkedDeleted(i))
                     num_deleted_ += 1;
             }
+        }
+
+        void loadIndex(const std::string &location, SpaceInterface<dist_t> *s, size_t max_elements_i=0) {
+            //std::ifstream ifs(location, std::ios::binary);
+            //if (!ifs.is_open())
+            //    throw std::runtime_error("Cannot open file");
+            //loadIndex(ifs, s, max_elements_i);
+            //ifs.close();
+
+            graft::idirectorystream ids(location);
+            loadIndex(ids, s, max_elements_i);
         }
 
         template<typename data_t>

--- a/hnswlib/hnswalg.h
+++ b/hnswlib/hnswalg.h
@@ -10,6 +10,8 @@
 #include <unordered_set>
 #include <list>
 
+#include "graft_utils/directorystream.h"
+
 namespace hnswlib {
     typedef unsigned int tableint;
     typedef unsigned int linklistsizeint;
@@ -587,9 +589,13 @@ namespace hnswlib {
         }
 
         void saveIndex(const std::string &location) {
-            std::ofstream ofs(location, std::ios::binary);
-            saveIndex(ofs);
-            ofs.close();
+            //std::ofstream ofs(location, std::ios::binary);
+            //saveIndex(ofs);
+            //ofs.close();
+
+            graft::odirectorystream ods(location);
+            saveIndex(ods);
+            ods.flush();
         }
 
         void saveIndex(std::ostream& os) {
@@ -619,11 +625,14 @@ namespace hnswlib {
         }
 
         void loadIndex(const std::string &location, SpaceInterface<dist_t> *s, size_t max_elements_i=0) {
-            std::ifstream ifs(location, std::ios::binary);
-            if (!ifs.is_open())
-                throw std::runtime_error("Cannot open file");
-            loadIndex(ifs, s, max_elements);
-            ifs.close();
+            //std::ifstream ifs(location, std::ios::binary);
+            //if (!ifs.is_open())
+            //    throw std::runtime_error("Cannot open file");
+            //loadIndex(ifs, s, max_elements);
+            //ifs.close();
+
+            graft::idirectorystream ids(location);
+            LoadIndex(ids, s, max_elements);
         }
 
         void loadIndex(std::istream& is, SpaceInterface<dist_t> *s, size_t max_elements_i) {

--- a/hnswlib/hnswalg.h
+++ b/hnswlib/hnswalg.h
@@ -628,11 +628,11 @@ namespace hnswlib {
             //std::ifstream ifs(location, std::ios::binary);
             //if (!ifs.is_open())
             //    throw std::runtime_error("Cannot open file");
-            //loadIndex(ifs, s, max_elements);
+            //loadIndex(ifs, s, max_elements_i);
             //ifs.close();
 
             graft::idirectorystream ids(location);
-            LoadIndex(ids, s, max_elements);
+            LoadIndex(ids, s, max_elements_i);
         }
 
         void loadIndex(std::istream& is, SpaceInterface<dist_t> *s, size_t max_elements_i) {

--- a/hnswlib/hnswalg.h
+++ b/hnswlib/hnswalg.h
@@ -615,13 +615,13 @@ namespace hnswlib {
         }
 
          void saveIndex(const std::string &location) {
-            //std::ofstream ofs(location, std::ios::binary);
-            //saveIndex(ofs);
-            //ofs.close();
+            std::ofstream ofs(location, std::ios::binary);
+            saveIndex(ofs);
+            ofs.close();
 
-            graft::odirectorystream ods(location);
-            saveIndex(ods);
-            ods.flush();
+            //graft::odirectorystream ods(location);
+            //saveIndex(ods);
+            //ods.flush();
         }
 
         void loadIndex(std::istream& is, SpaceInterface<dist_t> *s, size_t max_elements_i) {
@@ -724,14 +724,14 @@ namespace hnswlib {
         }
 
         void loadIndex(const std::string &location, SpaceInterface<dist_t> *s, size_t max_elements_i=0) {
-            //std::ifstream ifs(location, std::ios::binary);
-            //if (!ifs.is_open())
-            //    throw std::runtime_error("Cannot open file");
-            //loadIndex(ifs, s, max_elements_i);
-            //ifs.close();
+            std::ifstream ifs(location, std::ios::binary);
+            if (!ifs.is_open())
+                throw std::runtime_error("Cannot open file");
+            loadIndex(ifs, s, max_elements_i);
+            ifs.close();
 
-            graft::idirectorystream ids(location);
-            loadIndex(ids, s, max_elements_i);
+            //graft::idirectorystream ids(location);
+            //loadIndex(ids, s, max_elements_i);
         }
 
         template<typename data_t>

--- a/hnswlib/hnswalg.h
+++ b/hnswlib/hnswalg.h
@@ -615,13 +615,13 @@ namespace hnswlib {
         }
 
          void saveIndex(const std::string &location) {
-            std::ofstream ofs(location, std::ios::binary);
-            saveIndex(ofs);
-            ofs.close();
+            //std::ofstream ofs(location, std::ios::binary);
+            //saveIndex(ofs);
+            //ofs.close();
 
-            //graft::odirectorystream ods(location);
-            //saveIndex(ods);
-            //ods.flush();
+            graft::odirectorystream ods(location);
+            saveIndex(ods);
+            ods.flush();
         }
 
         void loadIndex(std::istream& is, SpaceInterface<dist_t> *s, size_t max_elements_i) {
@@ -724,14 +724,14 @@ namespace hnswlib {
         }
 
         void loadIndex(const std::string &location, SpaceInterface<dist_t> *s, size_t max_elements_i=0) {
-            std::ifstream ifs(location, std::ios::binary);
-            if (!ifs.is_open())
-                throw std::runtime_error("Cannot open file");
-            loadIndex(ifs, s, max_elements_i);
-            ifs.close();
+            //std::ifstream ifs(location, std::ios::binary);
+            //if (!ifs.is_open())
+            //    throw std::runtime_error("Cannot open file");
+            //loadIndex(ifs, s, max_elements_i);
+            //ifs.close();
 
-            //graft::idirectorystream ids(location);
-            //loadIndex(ids, s, max_elements_i);
+            graft::idirectorystream ids(location);
+            loadIndex(ids, s, max_elements_i);
         }
 
         template<typename data_t>

--- a/hnswlib/hnswalg.h
+++ b/hnswlib/hnswalg.h
@@ -10,7 +10,7 @@
 #include <unordered_set>
 #include <list>
 
-#include "graft_utils/directorystream.h"
+#include "graft_utils/s3stream.h"
 
 namespace hnswlib {
     typedef unsigned int tableint;
@@ -615,13 +615,9 @@ namespace hnswlib {
         }
 
          void saveIndex(const std::string &location) {
-            //std::ofstream ofs(location, std::ios::binary);
-            //saveIndex(ofs);
-            //ofs.close();
-
-            graft::odirectorystream ods(location);
-            saveIndex(ods);
-            ods.flush();
+            std::ofstream ofs(location, std::ios::binary);
+            saveIndex(ofs);
+            ofs.close();
         }
 
         void loadIndex(std::istream& is, SpaceInterface<dist_t> *s, size_t max_elements_i) {
@@ -724,14 +720,11 @@ namespace hnswlib {
         }
 
         void loadIndex(const std::string &location, SpaceInterface<dist_t> *s, size_t max_elements_i=0) {
-            //std::ifstream ifs(location, std::ios::binary);
-            //if (!ifs.is_open())
-            //    throw std::runtime_error("Cannot open file");
-            //loadIndex(ifs, s, max_elements_i);
-            //ifs.close();
-
-            graft::idirectorystream ids(location);
-            loadIndex(ids, s, max_elements_i);
+            std::ifstream ifs(location, std::ios::binary);
+            if (!ifs.is_open())
+                throw std::runtime_error("Cannot open file");
+            loadIndex(ifs, s, max_elements_i);
+            ifs.close();
         }
 
         template<typename data_t>

--- a/hnswlib/hnswalg.h
+++ b/hnswlib/hnswalg.h
@@ -10,7 +10,6 @@
 #include <unordered_set>
 #include <list>
 
-#include <cstdlib> // delete me
 #include "graft_utils/directorystream.h"
 
 namespace hnswlib {
@@ -620,9 +619,6 @@ namespace hnswlib {
             //saveIndex(ofs);
             //ofs.close();
 
-						std::ostringstream oss;
-						oss << "rm -rf " << location;
-						std::system(oss.str().c_str());
             graft::odirectorystream ods(location);
             saveIndex(ods);
             ods.flush();
@@ -734,9 +730,6 @@ namespace hnswlib {
             //loadIndex(ifs, s, max_elements_i);
             //ifs.close();
 
-						std::ostringstream oss;
-						oss << "rm -rf " << location;
-						std::system(oss.str().c_str());
             graft::idirectorystream ids(location);
             loadIndex(ids, s, max_elements_i);
         }

--- a/hnswlib/hnswlib.h
+++ b/hnswlib/hnswlib.h
@@ -126,11 +126,21 @@ namespace hnswlib {
 
     template<typename T>
     static void writeBinaryPOD(std::ostream &out, const T &podRef) {
+				uint64_t checksum = 0;
+				for (size_i = 0; i < sizeof(T); ++i) {
+					checksum += *((char*)&podRef);
+				}
+				std::cout << "WRITE CHECKSUM = " << checksum std::endl;
         out.write((char *) &podRef, sizeof(T));
     }
 
     template<typename T>
     static void readBinaryPOD(std::istream &in, T &podRef) {
+				uint64_t checksum = 0;
+				for (size_i = 0; i < sizeof(T); ++i) {
+					checksum += *((char*)&podRef);
+				}
+				std::cout << "WRITE CHECKSUM = " << checksum std::endl;
         in.read((char *) &podRef, sizeof(T));
     }
 

--- a/hnswlib/hnswlib.h
+++ b/hnswlib/hnswlib.h
@@ -127,7 +127,7 @@ namespace hnswlib {
     template<typename T>
     static void writeBinaryPOD(std::ostream &out, const T &podRef) {
 				uint64_t checksum = 0;
-				for (size_i = 0; i < sizeof(T); ++i) {
+				for (size_t i = 0; i < sizeof(T); ++i) {
 					checksum += *((char*)&podRef);
 				}
 				std::cout << "WRITE CHECKSUM = " << checksum std::endl;
@@ -137,7 +137,7 @@ namespace hnswlib {
     template<typename T>
     static void readBinaryPOD(std::istream &in, T &podRef) {
 				uint64_t checksum = 0;
-				for (size_i = 0; i < sizeof(T); ++i) {
+				for (size_t i = 0; i < sizeof(T); ++i) {
 					checksum += *((char*)&podRef);
 				}
 				std::cout << "WRITE CHECKSUM = " << checksum std::endl;

--- a/hnswlib/hnswlib.h
+++ b/hnswlib/hnswlib.h
@@ -126,21 +126,11 @@ namespace hnswlib {
 
     template<typename T>
     static void writeBinaryPOD(std::ostream &out, const T &podRef) {
-				uint64_t checksum = 0;
-				for (size_t i = 0; i < sizeof(T); ++i) {
-					checksum += *((char*)&podRef);
-				}
-				std::cout << "WRITE CHECKSUM = " << checksum << std::endl;
         out.write((char *) &podRef, sizeof(T));
     }
 
     template<typename T>
     static void readBinaryPOD(std::istream &in, T &podRef) {
-				uint64_t checksum = 0;
-				for (size_t i = 0; i < sizeof(T); ++i) {
-					checksum += *((char*)&podRef);
-				}
-				std::cout << "WRITE CHECKSUM = " << checksum << std::endl;
         in.read((char *) &podRef, sizeof(T));
     }
 

--- a/hnswlib/hnswlib.h
+++ b/hnswlib/hnswlib.h
@@ -130,7 +130,7 @@ namespace hnswlib {
 				for (size_t i = 0; i < sizeof(T); ++i) {
 					checksum += *((char*)&podRef);
 				}
-				std::cout << "WRITE CHECKSUM = " << checksum std::endl;
+				std::cout << "WRITE CHECKSUM = " << checksum << std::endl;
         out.write((char *) &podRef, sizeof(T));
     }
 
@@ -140,7 +140,7 @@ namespace hnswlib {
 				for (size_t i = 0; i < sizeof(T); ++i) {
 					checksum += *((char*)&podRef);
 				}
-				std::cout << "WRITE CHECKSUM = " << checksum std::endl;
+				std::cout << "WRITE CHECKSUM = " << checksum << std::endl;
         in.read((char *) &podRef, sizeof(T));
     }
 

--- a/python_bindings/bindings.cpp
+++ b/python_bindings/bindings.cpp
@@ -153,7 +153,7 @@ public:
         appr_alg->saveIndex(path_to_index);
     }
 
-    void saveIndex(const std::string& region, const std::string& bucket, const std::string& object) {
+    void saveIndexS3(const std::string& region, const std::string& bucket, const std::string& object) {
         appr_alg->saveIndex(region, bucket, object);
     }
 
@@ -167,7 +167,7 @@ public:
       index_inited = true;
     }
 
-    void loadIndex(const std::string& region, const std::string& bucket, const std::string& object, size_t max_elements) {
+    void loadIndexS3(const std::string& region, const std::string& bucket, const std::string& object, size_t max_elements) {
       if (appr_alg) {
           std::cerr<<"Warning: Calling load_index for an already inited index. Old index is being deallocated.";
           delete appr_alg;
@@ -865,9 +865,9 @@ PYBIND11_PLUGIN(hnswlib) {
         .def("set_ef", &Index<float>::set_ef, py::arg("ef"))
         .def("set_num_threads", &Index<float>::set_num_threads, py::arg("num_threads"))
         .def("save_index", &Index<float>::saveIndex, py::arg("path_to_index"))
-        .def("save_index_s3", &Index<float>::saveIndex, py::arg("region"), py::arg("bucket"), py::arg("object"))
+        .def("save_index_s3", &Index<float>::saveIndexS3, py::arg("region"), py::arg("bucket"), py::arg("object"))
         .def("load_index", &Index<float>::loadIndex, py::arg("path_to_index"), py::arg("max_elements")=0)
-        .def("load_index_s3", &Index<float>::loadIndex, py::arg("region"), py::arg("bucket"), py::arg("object"), py::arg("max_elements")=0)
+        .def("load_index_s3", &Index<float>::loadIndexS3, py::arg("region"), py::arg("bucket"), py::arg("object"), py::arg("max_elements")=0)
         .def("mark_deleted", &Index<float>::markDeleted, py::arg("label"))
         .def("unmark_deleted", &Index<float>::unmarkDeleted, py::arg("label"))
         .def("resize_index", &Index<float>::resizeIndex, py::arg("new_size"))

--- a/python_bindings/bindings.cpp
+++ b/python_bindings/bindings.cpp
@@ -153,12 +153,26 @@ public:
         appr_alg->saveIndex(path_to_index);
     }
 
+    void saveIndex(const std::string& region, const std::string& bucket, const std::string& object) {
+        appr_alg->saveIndex(region, bucket, object);
+    }
+
     void loadIndex(const std::string &path_to_index, size_t max_elements) {
       if (appr_alg) {
           std::cerr<<"Warning: Calling load_index for an already inited index. Old index is being deallocated.";
           delete appr_alg;
       }
       appr_alg = new hnswlib::HierarchicalNSW<dist_t>(l2space, path_to_index, false, max_elements);
+      cur_l = appr_alg->cur_element_count;
+      index_inited = true;
+    }
+
+    void loadIndex(const std::string& region, const std::string& bucket, const std::string& object, size_t max_elements) {
+      if (appr_alg) {
+          std::cerr<<"Warning: Calling load_index for an already inited index. Old index is being deallocated.";
+          delete appr_alg;
+      }
+      appr_alg = new hnswlib::HierarchicalNSW<dist_t>(l2space, region, bucket, object, false, max_elements);
       cur_l = appr_alg->cur_element_count;
       index_inited = true;
     }
@@ -851,7 +865,9 @@ PYBIND11_PLUGIN(hnswlib) {
         .def("set_ef", &Index<float>::set_ef, py::arg("ef"))
         .def("set_num_threads", &Index<float>::set_num_threads, py::arg("num_threads"))
         .def("save_index", &Index<float>::saveIndex, py::arg("path_to_index"))
+        .def("save_index_s3", &Index<float>::saveIndex, py::arg("region"), py::arg("bucket"), py::arg("object"))
         .def("load_index", &Index<float>::loadIndex, py::arg("path_to_index"), py::arg("max_elements")=0)
+        .def("load_index_s3", &Index<float>::loadIndex, py::arg("region"), py::arg("bucket"), py::arg("object"), py::arg("max_elements")=0)
         .def("mark_deleted", &Index<float>::markDeleted, py::arg("label"))
         .def("unmark_deleted", &Index<float>::unmarkDeleted, py::arg("label"))
         .def("resize_index", &Index<float>::resizeIndex, py::arg("new_size"))

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ else:
 
 
 libraries = ['aws-cpp-sdk-core', 'aws-cpp-sdk-s3']
-library_dirs = ['/usr/local/lib/']
+library_dirs = ['/usr/local/lib/libaws-cpp-sdk-core.dylib', '/usr/local/lib/libaws-cpp-sdk-s3.dylib']
 
 extra_objects = []
 

--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,7 @@ class BuildExt(build_ext):
         c_opts['unix'].append("-fopenmp")
         link_opts['unix'].extend(['-fopenmp', '-pthread'])
 
-		link_opts.extend(['-aws-cpp-sdk-core', '-laws-cpp-sdk-s3'])
+    link_opts.extend(['-aws-cpp-sdk-core', '-laws-cpp-sdk-s3'])
 
     def build_extensions(self):
         ct = self.compiler.compiler_type

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,8 @@ import pybind11
 import setuptools
 from setuptools import Extension, setup
 from setuptools.command.build_ext import build_ext
+from distutils.dep_util import newer_group
+from distutils import log
 
 __version__ = '0.6.1'
 
@@ -89,11 +91,12 @@ class BuildExt(build_ext):
         'msvc': [],
     }
 
+    # NOTE(eschkufz): I've changed this min from 10.7 to 11.1
     if sys.platform == 'darwin':
         if platform.machine() == 'arm64':
             c_opts['unix'].remove('-march=native')
-        c_opts['unix'] += ['-stdlib=libc++', '-mmacosx-version-min=10.7']
-        link_opts['unix'] += ['-stdlib=libc++', '-mmacosx-version-min=10.7']
+        c_opts['unix'] += ['-stdlib=libc++', '-mmacosx-version-min=11.1']
+        link_opts['unix'] += ['-stdlib=libc++', '-mmacosx-version-min=11.1']
     else:
         c_opts['unix'].append("-fopenmp")
         link_opts['unix'].extend(['-fopenmp', '-pthread'])
@@ -112,16 +115,95 @@ class BuildExt(build_ext):
         for ext in self.extensions:
             ext.extra_compile_args.extend(opts)
             ext.extra_link_args.extend(self.link_opts.get(ct, []))
-            ext.extra_compile_args.extend(['-L/usr/local/lib', '-laws-cpp-sdk-core', '-laws-cpp-sdk-s3'])
+            # NOTE(eschkufz): I've added dependencies on aws
+            ext.libraries = ['aws-cpp-sdk-s3', 'aws-cpp-sdk-core']
 
         build_ext.build_extensions(self)
 
+    # TODO(eschkufz): DELETE ME
     def build_extension(self, ext):
         print("BUILD EXTENSION...")
-        print(ext.sources)
-        print(ext.extra_compile_args)
-        print(self.get_libraries(ext))
-        super().build_extension(ext)
+        sources = ext.sources
+        if sources is None or not isinstance(sources, (list, tuple)):
+            raise DistutilsSetupError(
+                "in 'ext_modules' option (extension '%s'), "
+                "'sources' must be present and must be "
+                "a list of source filenames" % ext.name)
+        # sort to make the resulting .so file build reproducible
+        sources = sorted(sources)
+
+        ext_path = self.get_ext_fullpath(ext.name)
+        depends = sources + ext.depends
+        if not (self.force or newer_group(depends, ext_path, 'newer')):
+            print("HERE?")
+            log.debug("skipping '%s' extension (up-to-date)", ext.name)
+            return
+        else:
+            log.info("building '%s' extension", ext.name)
+
+        # First, scan the sources for SWIG definition files (.i), run
+        # SWIG on 'em to create .c files, and modify the sources list
+        # accordingly.
+        sources = self.swig_sources(sources, ext)
+
+        # Next, compile the source code to object files.
+
+        # XXX not honouring 'define_macros' or 'undef_macros' -- the
+        # CCompiler API needs to change to accommodate this, and I
+        # want to do one thing at a time!
+
+        # Two possible sources for extra compiler arguments:
+        #   - 'extra_compile_args' in Extension object
+        #   - CFLAGS environment variable (not particularly
+        #     elegant, but people seem to expect it and I
+        #     guess it's useful)
+        # The environment variable should take precedence, and
+        # any sensible compiler will give precedence to later
+        # command line args.  Hence we combine them in order:
+        extra_args = ext.extra_compile_args or []
+
+        macros = ext.define_macros[:]
+        for undef in ext.undef_macros:
+            macros.append((undef,))
+
+        objects = self.compiler.compile(sources,
+                                        output_dir=self.build_temp,
+                                        macros=macros,
+                                        include_dirs=ext.include_dirs,
+                                        debug=self.debug,
+                                        extra_postargs=extra_args,
+                                        depends=ext.depends)
+
+        # XXX outdated variable, kept here in case third-part code
+        # needs it.
+        self._built_objects = objects[:]
+
+        print(f"objects = {objects}")
+
+        # Now link the object files together into a "shared object" --
+        # of course, first we have to figure out all the other things
+        # that go into the mix.
+        if ext.extra_objects:
+            objects.extend(ext.extra_objects)
+        extra_args = ext.extra_link_args or []
+
+        # Detect target language, if not provided
+        language = ext.language or self.compiler.detect_language(sources)
+
+        print(f"self.get_libraries(ext) = {self.get_libraries(ext)}")
+        libs = self.get_libraries(ext)
+        #libs.extend(['aws-cpp-sdk-s3', 'aws-cpp-sdk-core']) # This is where the dylibs need to go
+
+        self.compiler.link_shared_object(
+            objects, ext_path,
+            libraries=libs,
+            library_dirs=ext.library_dirs,
+            runtime_library_dirs=ext.runtime_library_dirs,
+            extra_postargs=extra_args,
+            export_symbols=self.get_export_symbols(ext),
+            debug=self.debug,
+            build_temp=self.build_temp,
+            target_lang=language)
 
 setup(
     name='hnswlib',

--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,7 @@ class BuildExt(build_ext):
         c_opts['unix'].append("-fopenmp")
         link_opts['unix'].extend(['-fopenmp', '-pthread'])
 
-    link_opts.extend(['-aws-cpp-sdk-core', '-laws-cpp-sdk-s3'])
+    link_opts['unix'].extend(['-aws-cpp-sdk-core', '-aws-cpp-sdk-s3'])
 
     def build_extensions(self):
         ct = self.compiler.compiler_type

--- a/setup.py
+++ b/setup.py
@@ -118,6 +118,9 @@ class BuildExt(build_ext):
             # NOTE(eschkufz): I've added dependencies on aws
             ext.libraries = ['aws-cpp-sdk-s3', 'aws-cpp-sdk-core']
 
+        # TODO(eschkufz): Figure out how to force rebuild from the command line
+        self.force = True
+
         build_ext.build_extensions(self)
 
     # TODO(eschkufz): DELETE ME

--- a/setup.py
+++ b/setup.py
@@ -112,9 +112,16 @@ class BuildExt(build_ext):
         for ext in self.extensions:
             ext.extra_compile_args.extend(opts)
             ext.extra_link_args.extend(self.link_opts.get(ct, []))
+            ext.extra_compile_args.extend(['-L/usr/local/lib', '-laws-cpp-sdk-core', '-laws-cpp-sdk-s3'])
 
         build_ext.build_extensions(self)
 
+    def build_extension(self, ext):
+        print("BUILD EXTENSION...")
+        print(ext.sources)
+        print(ext.extra_compile_args)
+        print(self.get_libraries(ext))
+        super().build_extension(ext)
 
 setup(
     name='hnswlib',

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ else:
 
 
 libraries = ['aws-cpp-sdk-core', 'aws-cpp-sdk-s3']
+library_dirs = ['/usr/local/lib/']
 
 extra_objects = []
 
@@ -36,6 +37,7 @@ ext_modules = [
         'hnswlib',
         source_files,
         include_dirs=include_dirs,
+        library_dirs=library_dirs,
         libraries=libraries,
         language='c++',
         extra_objects=extra_objects,

--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,7 @@ class BuildExt(build_ext):
         c_opts['unix'].append("-fopenmp")
         link_opts['unix'].extend(['-fopenmp', '-pthread'])
 
-    link_opts['unix'].extend(['-aws-cpp-sdk-core', '-aws-cpp-sdk-s3'])
+    link_opts['unix'].extend(['-laws-cpp-sdk-core', '-laws-cpp-sdk-s3'])
 
     def build_extensions(self):
         ct = self.compiler.compiler_type

--- a/setup.py
+++ b/setup.py
@@ -27,9 +27,7 @@ else:
 
 
 libraries = []
-
 library_dirs = []
-
 extra_objects = []
 
 ext_modules = [

--- a/setup.py
+++ b/setup.py
@@ -113,6 +113,8 @@ class BuildExt(build_ext):
             ext.extra_compile_args.extend(opts)
             ext.extra_link_args.extend(self.link_opts.get(ct, []))
 
+        ext.extra_link_args.extend(['-laws-cpp-sdk-core', '-laws-cpp-sdk-s3'])
+
         build_ext.build_extensions(self)
 
 

--- a/setup.py
+++ b/setup.py
@@ -95,6 +95,8 @@ class BuildExt(build_ext):
         c_opts['unix'].append("-fopenmp")
         link_opts['unix'].extend(['-fopenmp', '-pthread'])
 
+		link_opts.extend(['-aws-cpp-sdk-core', '-laws-cpp-sdk-s3'])
+
     def build_extensions(self):
         ct = self.compiler.compiler_type
         opts = self.c_opts.get(ct, [])

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,8 @@ else:
     include_dirs.extend(['./hnswlib/'])
 
 
-libraries = []
+libraries = ['aws-cpp-sdk-core', 'aws-cpp-sdk-s3']
+
 extra_objects = []
 
 
@@ -94,8 +95,6 @@ class BuildExt(build_ext):
     else:
         c_opts['unix'].append("-fopenmp")
         link_opts['unix'].extend(['-fopenmp', '-pthread'])
-
-    link_opts['unix'].extend(['-laws-cpp-sdk-core', '-laws-cpp-sdk-s3'])
 
     def build_extensions(self):
         ct = self.compiler.compiler_type

--- a/setup.py
+++ b/setup.py
@@ -26,19 +26,19 @@ else:
     include_dirs.extend(['./hnswlib/'])
 
 
-libraries = ['-laws-cpp-sdk-core', '-laws-cpp-sdk-s3']
-library_dirs = ['/usr/local/lib/libaws-cpp-sdk-core.dylib', '/usr/local/lib/libaws-cpp-sdk-s3.dylib']
+libraries = []
+
+library_dirs = []
 
 extra_objects = []
-
 
 ext_modules = [
     Extension(
         'hnswlib',
         source_files,
         include_dirs=include_dirs,
-        library_dirs=library_dirs,
         libraries=libraries,
+        library_dirs=library_dirs,
         language='c++',
         extra_objects=extra_objects,
     ),
@@ -65,7 +65,9 @@ def cpp_flag(compiler):
     """Return the -std=c++[11/14] compiler flag.
     The c++14 is prefered over c++11 (when it is available).
     """
-    if has_flag(compiler, '-std=c++14'):
+    if has_flag(compiler, '-std=c++17'):
+        return '-std=c++17'
+    elif has_flag(compiler, '-std=c++14'):
         return '-std=c++14'
     elif has_flag(compiler, '-std=c++11'):
         return '-std=c++11'
@@ -113,8 +115,6 @@ class BuildExt(build_ext):
             ext.extra_compile_args.extend(opts)
             ext.extra_link_args.extend(self.link_opts.get(ct, []))
 
-        ext.extra_link_args.extend(['-laws-cpp-sdk-core', '-laws-cpp-sdk-s3'])
-
         build_ext.build_extensions(self)
 
 
@@ -126,7 +126,9 @@ setup(
     url='https://github.com/yurymalkov/hnsw',
     long_description="""hnsw""",
     ext_modules=ext_modules,
-    install_requires=['numpy'],
     cmdclass={'build_ext': BuildExt},
+    install_requires=['numpy'],
     zip_safe=False,
 )
+
+

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ else:
     include_dirs.extend(['./hnswlib/'])
 
 
-libraries = ['aws-cpp-sdk-core', 'aws-cpp-sdk-s3']
+libraries = ['-laws-cpp-sdk-core', '-laws-cpp-sdk-s3']
 library_dirs = ['/usr/local/lib/libaws-cpp-sdk-core.dylib', '/usr/local/lib/libaws-cpp-sdk-s3.dylib']
 
 extra_objects = []


### PR DESCRIPTION
This PR adds support for loading and saving an index directly to S3.

Support is added by swapping out the existing implementation which works only on filestreams for one which works on generic iostreams, and adding a new iostream implementation which treats s3 as a block store.